### PR TITLE
Use `lurk` as the binary name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ authors = ["Jakob Waibel <mail@jakobwaibel.com>"]
 description = "lurk is a pretty (simple) alternative to strace."
 license = "AGPL-3.0"
 
+[[bin]]
+name = "lurk"
+path = "src/main.rs"
+
 [dependencies]
 ansi_term = "0.12"
 clap = { version = "3.1.18", features = ["derive"] }


### PR DESCRIPTION
> **Note**: Since the crate name `lurk` was already gone, `lurk` is called `lurk-cli` when installing via `cargo`.

Even though the crate is named `lurk-cli` you can easily name the produced binary `lurk` if you want that.