### PR TITLE
docs: add installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ sudo install /tmp/lurk /usr/local/bin
 cargo install lurk-cli
 ```
 
+### Arch Linux
+```sh
+pacman -S lurk
+```
+
 ## Usage
 
 To get a quick overview, you can run `lurk --help`:


### PR DESCRIPTION
`lurk` is available in the community repository: https://archlinux.org/packages/community/x86_64/lurk/
