### PR TITLE
Fix `test_args_simple`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -224,6 +224,6 @@ mod tests {
     #[test]
     fn test_args_simple() {
         let args = Args::parse_from(&["lurk", "app"]);
-        assert_eq!(args.command, ArgCommand::Command(vec!["app".to_string()]));
+        assert_eq!(args.command, Some(ArgCommand::Command(vec!["app".to_string()])));
     }
 }


### PR DESCRIPTION
`args.command` has changed to `Option<ArgCommand>`, which prevents test from building.