### PR TITLE
Reworked trace-loop & adding support for the 27 syscalls from 424 to 450

### DIFF
--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -284,32 +284,6 @@ pub static TRACE_CLOCK: SysnoSet = SysnoSet::new(&[
     clock_adjtime,
 ]);
 
-/*
-macro_rules! syscall {
-    ($name:ident $(,)?) => {
-        (Sysno::$name, [None, None, None, None, None, None])
-    };
-    ($name:ident, $arg0:ident $(,)?) => {
-        (Sysno::$name, [$arg0, None, None, None, None, None])
-    };
-    ($name:ident, $arg0:ident, $arg1:ident $(,)?) => {
-        (Sysno::$name, [$arg0, $arg1, None, None, None, None])
-    };
-    ($name:ident, $arg0:ident, $arg1:ident, $arg2:ident $(,)?) => {
-        (Sysno::$name, [$arg0, $arg1, $arg2, None, None, None])
-    };
-    ($name:ident, $arg0:ident, $arg1:ident, $arg2:ident, $arg3:ident $(,)?) => {
-        (Sysno::$name, [$arg0, $arg1, $arg2, $arg3, None, None])
-    };
-    ($name:ident, $arg0:ident, $arg1:ident, $arg2:ident, $arg3:ident, $arg4:ident $(,)?) => {
-        (Sysno::$name, [$arg0, $arg1, $arg2, $arg3, $arg4, None])
-    };
-    ($name:ident, $arg0:ident, $arg1:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident $(,)?) => {
-        (Sysno::$name, [$arg0, $arg1, $arg2, $arg3, $arg4, $arg5])
-    };
-}
-*/
-
 macro_rules! syscall {
     ($name:ident $(,)?) => {
         Some((Sysno::$name, [None, None, None, None, None, None]))

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -227,6 +227,7 @@ pub static TRACE_SIGNAL: SysnoSet = SysnoSet::new(&[
     signalfd,
     signalfd4,
     rt_tgsigqueueinfo,
+    pidfd_send_signal,
 ]);
 
 pub static TRACE_MEMORY: SysnoSet = SysnoSet::new(&[
@@ -283,6 +284,7 @@ pub static TRACE_CLOCK: SysnoSet = SysnoSet::new(&[
     clock_adjtime,
 ]);
 
+/*
 macro_rules! syscall {
     ($name:ident $(,)?) => {
         (Sysno::$name, [None, None, None, None, None, None])
@@ -306,12 +308,37 @@ macro_rules! syscall {
         (Sysno::$name, [$arg0, $arg1, $arg2, $arg3, $arg4, $arg5])
     };
 }
+*/
+
+macro_rules! syscall {
+    ($name:ident $(,)?) => {
+        Some((Sysno::$name, [None, None, None, None, None, None]))
+    };
+    ($name:ident, $arg0:ident $(,)?) => {
+        Some((Sysno::$name, [$arg0, None, None, None, None, None]))
+    };
+    ($name:ident, $arg0:ident, $arg1:ident $(,)?) => {
+        Some((Sysno::$name, [$arg0, $arg1, None, None, None, None]))
+    };
+    ($name:ident, $arg0:ident, $arg1:ident, $arg2:ident $(,)?) => {
+        Some((Sysno::$name, [$arg0, $arg1, $arg2, None, None, None]))
+    };
+    ($name:ident, $arg0:ident, $arg1:ident, $arg2:ident, $arg3:ident $(,)?) => {
+        Some((Sysno::$name, [$arg0, $arg1, $arg2, $arg3, None, None]))
+    };
+    ($name:ident, $arg0:ident, $arg1:ident, $arg2:ident, $arg3:ident, $arg4:ident $(,)?) => {
+        Some((Sysno::$name, [$arg0, $arg1, $arg2, $arg3, $arg4, None]))
+    };
+    ($name:ident, $arg0:ident, $arg1:ident, $arg2:ident, $arg3:ident, $arg4:ident, $arg5:ident $(,)?) => {
+        Some((Sysno::$name, [$arg0, $arg1, $arg2, $arg3, $arg4, $arg5]))
+    };
+}
 
 const ADDR: Option<SyscallArgType> = Some(SyscallArgType::Addr);
 const INT: Option<SyscallArgType> = Some(SyscallArgType::Int);
 const STR: Option<SyscallArgType> = Some(SyscallArgType::Str);
 
-pub static SYSCALLS: [(Sysno, [Option<SyscallArgType>; 6]); 335] = [
+pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 451] = [
     // DESC
     syscall!(read, INT, STR, INT),
     // DESC
@@ -888,6 +915,127 @@ pub static SYSCALLS: [(Sysno, [Option<SyscallArgType>; 6]); 335] = [
     syscall!(statx, INT, STR, INT, INT, STR),
     syscall!(io_pgetevents),
     syscall!(rseq),
+    // We jump from syscall number 334 to 424 here
+    // See: https://git.musl-libc.org/cgit/musl/commit/?id=f3f96f2daa4d00f0e38489fb465cd0244b531abe
+    //      https://github.com/torvalds/linux/commit/0d6040d4681735dfc47565de288525de405a5c99
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    syscall!(pidfd_send_signal, INT, INT, ADDR, INT),
+    syscall!(io_uring_setup, INT, ADDR),
+    syscall!(io_uring_enter, INT, INT, INT, INT, ADDR, INT),
+    syscall!(io_uring_register, INT, INT, ADDR, INT),
+    syscall!(open_tree, INT, STR, INT),
+    syscall!(move_mount, INT, STR, INT, STR, INT),
+    syscall!(fsopen, STR, INT),
+    syscall!(fsconfig, INT, INT, STR, ADDR, INT),
+    syscall!(fsmount, INT, INT, INT),
+    syscall!(fspick, INT, STR, INT),
+    syscall!(pidfd_open, INT, INT),
+    syscall!(clone3, ADDR, INT),
+    syscall!(close_range, INT, INT, INT),
+    syscall!(openat2, INT, STR, ADDR, INT),
+    syscall!(pidfd_getfd, INT, INT, INT),
+    syscall!(faccessat2, INT, STR, INT, INT),
+    syscall!(process_madvise, INT, ADDR, INT, INT, INT),
+    syscall!(epoll_pwait2, INT, ADDR, INT, ADDR, ADDR, INT),
+    syscall!(mount_setattr, INT, STR, INT, ADDR, INT),
+    syscall!(quotactl_fd, INT, INT, INT, ADDR),
+    syscall!(landlock_create_ruleset, ADDR, INT, INT),
+    syscall!(landlock_add_rule, INT, INT, ADDR, INT),
+    syscall!(landlock_restrict_self, INT, INT),
+    syscall!(memfd_secret, INT),
+    syscall!(process_mrelease, INT, INT),
+    syscall!(futex_waitv, ADDR, INT, INT, ADDR, INT),
+    syscall!(set_mempolicy_home_node, INT, INT, INT, INT),
+    // 451 - cachestat not yet implemented by the syscall crate
+    // syscall!(cachestat, INT, INT, INT, INT)
 ];
 
 pub fn get_arg_value(registers: user_regs_struct, i: usize) -> c_ulonglong {
@@ -908,9 +1056,12 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::cast_sign_loss)]
     fn test_syscall_numbers() {
-        for (i, (sysno, ..)) in SYSCALLS.iter().enumerate() {
-            assert_eq!(i, sysno.id() as usize);
+        for (i, sysno, ..) in SYSCALLS.iter().enumerate() {
+            if let Some((sysno, _)) = sysno {
+                assert_eq!(i, sysno.id() as usize);
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ impl Tracer {
                         signal,
                         if coredump { "(core dumped)" } else { "" }
                     )?;
+                    break;
                 }
                 // WIFCONTINUED(status), this usually happens when a process receives a SIGCONT.
                 // Just continue with the next iteration of the loop.

--- a/src/syscall_info.rs
+++ b/src/syscall_info.rs
@@ -71,23 +71,27 @@ impl SyscallInfo {
             arg.write(output, string_limit)?;
         }
         write!(output, ") = ")?;
-        if use_colors {
-            let style = match self.result {
-                RetCode::Ok(_) => Green.bold(),
-                RetCode::Err(_) => Red.bold(),
-                RetCode::Address(_) => Yellow.bold(),
-            };
-            // TODO: it would be great if we can force termcolor to write
-            //       the styling prefix and suffix into the formatter.
-            //       This would allow us to use the same code for both cases,
-            //       and avoid additional string alloc
-            write!(output, "{}", style.paint(self.result.to_string()))
+        if self.syscall == Sysno::exit || self.syscall == Sysno::exit_group {
+            write!(output, "?")?;
         } else {
-            write!(output, "{}", self.result)
-        }?;
-        if show_duration {
-            // TODO: add an option to control each syscall duration scaling, e.g. ms, us, ns
-            write!(output, " <{:.6}ns>", self.duration.as_nanos())?;
+            if use_colors {
+                let style = match self.result {
+                    RetCode::Ok(_) => Green.bold(),
+                    RetCode::Err(_) => Red.bold(),
+                    RetCode::Address(_) => Yellow.bold(),
+                };
+                // TODO: it would be great if we can force termcolor to write
+                //       the styling prefix and suffix into the formatter.
+                //       This would allow us to use the same code for both cases,
+                //       and avoid additional string alloc
+                write!(output, "{}", style.paint(self.result.to_string()))
+            } else {
+                write!(output, "{}", self.result)
+            }?;
+            if show_duration {
+                // TODO: add an option to control each syscall duration scaling, e.g. ms, us, ns
+                write!(output, " <{:.6}ns>", self.duration.as_nanos())?;
+            }
         }
         Ok(writeln!(output)?)
     }


### PR DESCRIPTION
Heya, this PR lays some first groundwork in order to get to tracing parity with `strace` itself.
I've rewritten the main tracing-loop, to more robustly handle signals and the various other `ptrace` events (documented in code for now). It's still far from `strace`'s main tracing-loop, but already manages to fix some important bugs.

- Both `exit` and `exit_group` are now properly handled.
- `-f, --follow-forks` now actually follows forks.
- Running a binary that spawns threads won't hang if `-f` is not supplied.

Some notes of things that aren't yet implemented:
1. Various signals aren't passed to the child via `ptrace(PTRACE_SYSCALL, ...)`.
This needs some more complex fall-through logic for `WIFSTOPPED(status)` (implemented here in `WaitStatus::Stopped`).

2. `exec`-family syscalls can't report their arguments.
`lurk` uses `exec` from `std::os::unix::process` to load it's tracee into the forked process. This `exec` from `std::os::unix::process` issues various other syscalls (like `dup2`) before actually `execve`'ing. This makes it quite hard to properly implement logic to catch the arguments of any `exec`-family syscall. The usual trick to just `kill(getpid(), SIGSTOP)` after a `ptrace(PTRACE_TRACEME, ...)` request to give the parent a chance to catch the `execve`, won't do it in this case.

Additionaly I've also added the missing 27 syscalls from number 424 to 450.
Due to the syscall gap from 334 to 424 the solution's probably a bit iffy, but it works. Refactoring definitely welcome. This fixes #24 and probably a bunch of other binaries which rely on these newer syscalls.