### PR TITLE
Fix issue #5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ impl Tracer {
                     // Therefor issue a PTRACE_SYSCALL request to the parent to continue execution.
                     // This is also important if we trace without the following forks option.
                     if signal == Signal::SIGCHLD {
-                        self.issue_ptrace_syscall_request(pid, None)?;
+                        ptrace::cont(pid, signal)?;
                         continue;
                     }
 


### PR DESCRIPTION
This PR is intended to fix the bug mentioned in Issue #5.

When I use `lurk` to trace the system calls of the `sshd` process, I encounter a similar bug. After running 
```
lurk -p <sshd_pid> -f
``` 
And then using `exit` to exit the SSH session, the interrupt message shows "logout," but the SSH process remains in a blocked state, and I am unable to return to the terminal.

![image](https://github.com/JakWai01/lurk/assets/72367456/0d5ee9c0-0740-4354-b6f7-80bdd9f27efa)

In the `pstree` command, you can see that the bash process still exists but has become a Zombie process.
![image](https://github.com/JakWai01/lurk/assets/72367456/8e1c5fc1-6f61-4041-bb4f-3aa32a4f6538)

In fact, I am also a newcomer to the Linux kernel, and I don't understand why using `PTRACE_SYSCALL` would cause the process to hang. Perhaps when using `PTRACE_SYSCALL`, the process is suspended between the entry and exit of each system call, but the process exited and there are no more subsequent `SYSCALL` calls in this case? However, using `PTRACE_CONT` does solve this problem by allowing the process to continue without interruption.