### PR TITLE
Change read_string to read_bytes

### DIFF
--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -310,23 +310,23 @@ macro_rules! syscall {
 
 const ADDR: Option<SyscallArgType> = Some(SyscallArgType::Addr);
 const INT: Option<SyscallArgType> = Some(SyscallArgType::Int);
-const STR: Option<SyscallArgType> = Some(SyscallArgType::Str);
+const BYTES: Option<SyscallArgType> = Some(SyscallArgType::Bytes);
 
 pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC
-    syscall!(read, INT, STR, INT),
+    syscall!(read, INT, BYTES, INT),
     // DESC
-    syscall!(write, INT, STR, INT),
+    syscall!(write, INT, BYTES, INT),
     // DESC, FILE
-    syscall!(open, STR, INT, INT),
+    syscall!(open, BYTES, INT, INT),
     // DESC
     syscall!(close, INT),
     // FILE, STAT, STAT_LIKE
-    syscall!(stat, STR, ADDR),
+    syscall!(stat, BYTES, ADDR),
     // DESC, FSTAT, STAT_LIKE
     syscall!(fstat, INT, ADDR),
     // FILE, LSTAT, STAT_LIKE
-    syscall!(lstat, STR, ADDR),
+    syscall!(lstat, BYTES, ADDR),
     // DESC
     syscall!(poll, ADDR, INT, INT),
     // DESC
@@ -347,15 +347,15 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(rt_sigreturn),
     syscall!(ioctl, INT, INT, ADDR),
     // DESC
-    syscall!(pread64, INT, STR, INT, INT),
+    syscall!(pread64, INT, BYTES, INT, INT),
     // DESC
-    syscall!(pwrite64, INT, STR, INT, INT),
+    syscall!(pwrite64, INT, BYTES, INT, INT),
     // DESC
     syscall!(readv, INT, ADDR, INT),
     // DESC
     syscall!(writev, INT, ADDR, INT),
     // FILE
-    syscall!(access, STR, INT),
+    syscall!(access, BYTES, INT),
     // DESC
     syscall!(pipe, INT, INT),
     // DESC
@@ -374,7 +374,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // IPC, MEMORY
     syscall!(shmat, INT, ADDR, INT),
     // IPC
-    syscall!(shmctl, INT, INT, STR),
+    syscall!(shmctl, INT, INT, BYTES),
     // DESC
     syscall!(dup, INT),
     // DESC
@@ -396,9 +396,9 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // NETWORK
     syscall!(accept, INT, ADDR, ADDR),
     // NETWORK
-    syscall!(sendto, INT, STR, INT, INT),
+    syscall!(sendto, INT, BYTES, INT, INT),
     // NETWORK
-    syscall!(recvfrom, INT, STR, INT, INT, ADDR, ADDR),
+    syscall!(recvfrom, INT, BYTES, INT, INT, ADDR, ADDR),
     // NETWORK
     syscall!(sendmsg, INT, ADDR, INT),
     // NETWORK
@@ -426,7 +426,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // PROCESS
     syscall!(vfork, ADDR),
     // PROCESS
-    syscall!(execve, STR, STR, STR),
+    syscall!(execve, BYTES, BYTES, BYTES),
     // PROCESS
     syscall!(exit, INT),
     // PROCESS
@@ -459,43 +459,43 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC
     syscall!(fdatasync, INT),
     // FILE
-    syscall!(truncate, STR, INT),
+    syscall!(truncate, BYTES, INT),
     // DESC
     syscall!(ftruncate, INT, INT),
     // DESC
     syscall!(getdents, INT, ADDR, INT),
     // FILE
-    syscall!(getcwd, STR, INT),
+    syscall!(getcwd, BYTES, INT),
     // FILE
-    syscall!(chdir, STR),
+    syscall!(chdir, BYTES),
     // DESC
     syscall!(fchdir, INT),
     // FILE
-    syscall!(rename, STR, STR),
+    syscall!(rename, BYTES, BYTES),
     // FILE
-    syscall!(mkdir, STR, INT),
+    syscall!(mkdir, BYTES, INT),
     // FILE
-    syscall!(rmdir, STR),
+    syscall!(rmdir, BYTES),
     // DESC, FILE
-    syscall!(creat, STR, INT),
+    syscall!(creat, BYTES, INT),
     // FILE
-    syscall!(link, STR, STR),
+    syscall!(link, BYTES, BYTES),
     // FILE
-    syscall!(unlink, STR),
+    syscall!(unlink, BYTES),
     // FILE
-    syscall!(symlink, STR, STR),
+    syscall!(symlink, BYTES, BYTES),
     // FILE
-    syscall!(readlink, STR, STR, INT),
+    syscall!(readlink, BYTES, BYTES, INT),
     // FILE
-    syscall!(chmod, STR, INT),
+    syscall!(chmod, BYTES, INT),
     // DESC
     syscall!(fchmod, INT, INT),
     // FILE
-    syscall!(chown, STR, INT, INT),
+    syscall!(chown, BYTES, INT, INT),
     // DESC
     syscall!(fchown, INT, INT, INT),
     // FILE
-    syscall!(lchown, STR, INT, INT),
+    syscall!(lchown, BYTES, INT, INT),
     syscall!(umask, INT),
     // CLOCK
     syscall!(gettimeofday, ADDR, ADDR),
@@ -506,7 +506,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(ptrace, ADDR, INT, ADDR, ADDR),
     // CREDS, PURE
     syscall!(getuid, ADDR),
-    syscall!(syslog, INT, STR, INT),
+    syscall!(syslog, INT, BYTES, INT),
     // CREDS, PURE
     syscall!(getgid, ADDR),
     // CREDS
@@ -560,19 +560,19 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // SIGNAL
     syscall!(sigaltstack, ADDR, ADDR),
     // FILE
-    syscall!(utime, STR, ADDR, INT),
+    syscall!(utime, BYTES, ADDR, INT),
     // FILE
-    syscall!(mknod, STR, INT, INT),
+    syscall!(mknod, BYTES, INT, INT),
     // FILE
     syscall!(uselib, ADDR),
     syscall!(personality, INT),
     // STATFS_LIKE
     syscall!(ustat, INT, ADDR),
     // FILE, STATFS, STATFS_LIKE
-    syscall!(statfs, STR, ADDR),
+    syscall!(statfs, BYTES, ADDR),
     // FILE, FSTATFS, STATFS_LIKE
     syscall!(fstatfs, INT, ADDR),
-    syscall!(sysfs, INT, STR),
+    syscall!(sysfs, INT, BYTES),
     syscall!(getpriority, INT, INT),
     syscall!(setpriority, INT, INT, INT),
     syscall!(sched_setparam, INT, ADDR),
@@ -593,41 +593,41 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(vhangup, ADDR),
     syscall!(modify_ldt, INT, ADDR, INT),
     // FILE
-    syscall!(pivot_root, STR, STR),
+    syscall!(pivot_root, BYTES, BYTES),
     syscall!(_sysctl, ADDR),
     // CREDS
     syscall!(prctl, INT, INT, INT, INT, INT),
     syscall!(arch_prctl, INT, ADDR),
     // CLOCK
-    syscall!(adjtimex, STR),
+    syscall!(adjtimex, BYTES),
     syscall!(setrlimit, INT, ADDR),
     // FILE
-    syscall!(chroot, STR),
+    syscall!(chroot, BYTES),
     syscall!(sync, INT),
     // FILE
-    syscall!(acct, STR),
+    syscall!(acct, BYTES),
     // CLOCK
     syscall!(settimeofday, ADDR, ADDR),
     // FILE
-    syscall!(mount, STR, STR, STR, INT, ADDR),
+    syscall!(mount, BYTES, BYTES, BYTES, INT, ADDR),
     // FILE
-    syscall!(umount2, STR, INT),
+    syscall!(umount2, BYTES, INT),
     // FILE
-    syscall!(swapon, STR, INT),
+    syscall!(swapon, BYTES, INT),
     // FILE
-    syscall!(swapoff, STR),
+    syscall!(swapoff, BYTES),
     syscall!(reboot, INT, INT, INT, ADDR),
-    syscall!(sethostname, STR, INT),
-    syscall!(setdomainname, STR, INT),
+    syscall!(sethostname, BYTES, INT),
+    syscall!(setdomainname, BYTES, INT),
     syscall!(iopl, INT),
     syscall!(ioperm, INT, INT, INT),
-    syscall!(create_module, STR, INT),
-    syscall!(init_module, ADDR, INT, STR),
-    syscall!(delete_module, STR, INT),
+    syscall!(create_module, BYTES, INT),
+    syscall!(init_module, ADDR, INT, BYTES),
+    syscall!(delete_module, BYTES, INT),
     syscall!(get_kernel_syms, ADDR),
-    syscall!(query_module, STR, INT, STR, INT, INT),
+    syscall!(query_module, BYTES, INT, BYTES, INT, INT),
     // FILE
-    syscall!(quotactl, INT, STR, INT, ADDR),
+    syscall!(quotactl, INT, BYTES, INT, ADDR),
     syscall!(nfsservctl, INT, ADDR, ADDR),
     // NETWORK
     syscall!(getpmsg),
@@ -641,29 +641,29 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC
     syscall!(readahead, INT, INT, INT),
     // FILE
-    syscall!(setxattr, STR, STR, ADDR, INT, INT),
+    syscall!(setxattr, BYTES, BYTES, ADDR, INT, INT),
     // FILE
-    syscall!(lsetxattr, STR, STR, ADDR, INT, INT),
+    syscall!(lsetxattr, BYTES, BYTES, ADDR, INT, INT),
     // DESC
-    syscall!(fsetxattr, INT, STR, ADDR, INT, INT),
+    syscall!(fsetxattr, INT, BYTES, ADDR, INT, INT),
     // FILE
-    syscall!(getxattr, STR, STR, ADDR, INT),
+    syscall!(getxattr, BYTES, BYTES, ADDR, INT),
     // FILE
-    syscall!(lgetxattr, STR, STR, ADDR, INT),
+    syscall!(lgetxattr, BYTES, BYTES, ADDR, INT),
     // DESC
-    syscall!(fgetxattr, INT, STR, ADDR, INT),
+    syscall!(fgetxattr, INT, BYTES, ADDR, INT),
     // FILE
-    syscall!(listxattr, STR, STR, INT),
+    syscall!(listxattr, BYTES, BYTES, INT),
     // FILE
-    syscall!(llistxattr, STR, STR, INT),
+    syscall!(llistxattr, BYTES, BYTES, INT),
     // DESC
-    syscall!(flistxattr, INT, STR, INT),
+    syscall!(flistxattr, INT, BYTES, INT),
     // FILE
-    syscall!(removexattr, STR, STR),
+    syscall!(removexattr, BYTES, BYTES),
     // FILE
-    syscall!(lremovexattr, STR, STR),
+    syscall!(lremovexattr, BYTES, BYTES),
     // DESC
-    syscall!(fremovexattr, INT, STR),
+    syscall!(fremovexattr, INT, BYTES),
     // PROCESS, SIGNAL
     syscall!(tkill, INT, INT),
     // CLOCK
@@ -680,7 +680,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(io_submit, INT, INT, ADDR),
     syscall!(io_cancel, INT, ADDR, ADDR),
     syscall!(get_thread_area, ADDR),
-    syscall!(lookup_dcookie, INT, STR, INT),
+    syscall!(lookup_dcookie, INT, BYTES, INT),
     // DESC
     syscall!(epoll_create, INT),
     syscall!(epoll_ctl_old, INT, INT, INT, ADDR),
@@ -716,7 +716,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // PROCESS
     syscall!(tgkill, INT, INT, INT),
     // FILE
-    syscall!(utimes, STR, ADDR),
+    syscall!(utimes, BYTES, ADDR),
     syscall!(vserver),
     // MEMORY
     syscall!(mbind, ADDR, INT, INT, INT, INT, INT),
@@ -725,10 +725,10 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // MEMORY
     syscall!(get_mempolicy, INT, INT, INT, ADDR, INT),
     // DESC
-    syscall!(mq_open, STR, INT),
-    syscall!(mq_unlink, STR),
+    syscall!(mq_open, BYTES, INT),
+    syscall!(mq_unlink, BYTES),
     // DESC
-    syscall!(mq_timedsend, INT, STR, INT, INT),
+    syscall!(mq_timedsend, INT, BYTES, INT, INT),
     // DESC
     syscall!(mq_timedreceive, INT, ADDR, INT, INT, ADDR),
     // DESC
@@ -738,45 +738,45 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(kexec_load, INT, INT, ADDR, INT),
     // PROCESS
     syscall!(waitid, INT, INT, INT, INT),
-    syscall!(add_key, STR, STR, ADDR, INT, INT),
-    syscall!(request_key, STR, STR, STR, INT),
+    syscall!(add_key, BYTES, BYTES, ADDR, INT, INT),
+    syscall!(request_key, BYTES, BYTES, BYTES, INT),
     syscall!(keyctl, INT),
     syscall!(ioprio_set, INT, INT),
     syscall!(ioprio_get, INT, INT),
     // DESC
     syscall!(inotify_init, ADDR),
     // DESC, FILE
-    syscall!(inotify_add_watch, INT, STR, INT),
+    syscall!(inotify_add_watch, INT, BYTES, INT),
     // DESC
     syscall!(inotify_rm_watch, INT, INT),
     // MEMORY
     syscall!(migrate_pages, INT, INT, INT, INT),
     // DESC, FILE
-    syscall!(openat, INT, STR, INT),
+    syscall!(openat, INT, BYTES, INT),
     // DESC, FILE
-    syscall!(mkdirat, INT, STR, INT),
+    syscall!(mkdirat, INT, BYTES, INT),
     // DESC, FILE
-    syscall!(mknodat, INT, STR, INT, INT),
+    syscall!(mknodat, INT, BYTES, INT, INT),
     // DESC, FILE
-    syscall!(fchownat, INT, STR, INT, INT, INT),
+    syscall!(fchownat, INT, BYTES, INT, INT, INT),
     // DESC, FILE
-    syscall!(futimesat, INT, STR, ADDR),
+    syscall!(futimesat, INT, BYTES, ADDR),
     // DESC, FILE, FSTAT, STAT_LIKE
-    syscall!(newfstatat, INT, STR, ADDR, INT),
+    syscall!(newfstatat, INT, BYTES, ADDR, INT),
     // DESC, FILE
-    syscall!(unlinkat, INT, STR, INT),
+    syscall!(unlinkat, INT, BYTES, INT),
     // DESC, FILE
-    syscall!(renameat, INT, STR, INT, STR),
+    syscall!(renameat, INT, BYTES, INT, BYTES),
     // DESC, FILE
-    syscall!(linkat, INT, STR, INT, STR, INT),
+    syscall!(linkat, INT, BYTES, INT, BYTES, INT),
     // DESC, FILE
-    syscall!(symlinkat, STR, INT, STR),
+    syscall!(symlinkat, BYTES, INT, BYTES),
     // DESC, FILE
-    syscall!(readlinkat, INT, STR, STR, INT),
+    syscall!(readlinkat, INT, BYTES, BYTES, INT),
     // DESC, FILE
-    syscall!(fchmodat, INT, STR, INT, INT),
+    syscall!(fchmodat, INT, BYTES, INT, INT),
     // DESC, FILE
-    syscall!(faccessat, INT, STR, INT, INT),
+    syscall!(faccessat, INT, BYTES, INT, INT),
     // DESC
     syscall!(pselect6, INT, INT, INT, INT, ADDR, INT),
     // DESC
@@ -795,7 +795,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // MEMORY
     syscall!(move_pages, INT, INT, ADDR, INT, INT, INT),
     // DESC, FILE
-    syscall!(utimensat, INT, STR, ADDR, INT),
+    syscall!(utimensat, INT, BYTES, ADDR, INT),
     // DESC
     syscall!(epoll_pwait, INT, ADDR, INT, INT, INT),
     // DESC, SIGNAL
@@ -836,10 +836,10 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC
     syscall!(fanotify_init, INT, INT),
     // DESC, FILE
-    syscall!(fanotify_mark, INT, INT, INT, INT, STR),
+    syscall!(fanotify_mark, INT, INT, INT, INT, BYTES),
     syscall!(prlimit64, INT, INT, ADDR, ADDR),
     // DESC, FILE
-    syscall!(name_to_handle_at, INT, STR, ADDR, INT, INT),
+    syscall!(name_to_handle_at, INT, BYTES, ADDR, INT, INT),
     // DESC
     syscall!(open_by_handle_at, INT, ADDR, INT),
     // CLOCK
@@ -855,21 +855,21 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(process_vm_writev, INT, ADDR, INT, ADDR, INT, INT),
     syscall!(kcmp, INT, INT, INT, INT, INT),
     // DESC
-    syscall!(finit_module, INT, STR, INT),
+    syscall!(finit_module, INT, BYTES, INT),
     syscall!(sched_setattr, INT, ADDR, INT),
     syscall!(sched_getattr, INT, ADDR, INT, INT),
     // DESC, FILE
-    syscall!(renameat2, INT, STR, INT, STR),
+    syscall!(renameat2, INT, BYTES, INT, BYTES),
     syscall!(seccomp, INT, INT, ADDR),
-    syscall!(getrandom, STR, INT, INT),
+    syscall!(getrandom, BYTES, INT, INT),
     // DESC
-    syscall!(memfd_create, STR, INT),
+    syscall!(memfd_create, BYTES, INT),
     // DESC
     syscall!(kexec_file_load, INT, INT, ADDR, INT),
     // DESC
     syscall!(bpf, INT, ADDR, INT),
     // DESC, PROCESS
-    syscall!(execveat, INT, STR, STR, STR, INT),
+    syscall!(execveat, INT, BYTES, BYTES, BYTES, INT),
     // DESC
     syscall!(userfaultfd, INT),
     syscall!(membarrier, INT, INT, INT),
@@ -886,7 +886,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(pkey_alloc, INT, INT),
     syscall!(pkey_free, INT),
     // DESC, FILE, FSTAT, STAT_LIKE
-    syscall!(statx, INT, STR, INT, INT, STR),
+    syscall!(statx, INT, BYTES, INT, INT, BYTES),
     syscall!(io_pgetevents),
     syscall!(rseq),
     // We jump from syscall number 334 to 424 here
@@ -985,21 +985,21 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(io_uring_setup, INT, ADDR),
     syscall!(io_uring_enter, INT, INT, INT, INT, ADDR, INT),
     syscall!(io_uring_register, INT, INT, ADDR, INT),
-    syscall!(open_tree, INT, STR, INT),
-    syscall!(move_mount, INT, STR, INT, STR, INT),
-    syscall!(fsopen, STR, INT),
-    syscall!(fsconfig, INT, INT, STR, ADDR, INT),
+    syscall!(open_tree, INT, BYTES, INT),
+    syscall!(move_mount, INT, BYTES, INT, BYTES, INT),
+    syscall!(fsopen, BYTES, INT),
+    syscall!(fsconfig, INT, INT, BYTES, ADDR, INT),
     syscall!(fsmount, INT, INT, INT),
-    syscall!(fspick, INT, STR, INT),
+    syscall!(fspick, INT, BYTES, INT),
     syscall!(pidfd_open, INT, INT),
     syscall!(clone3, ADDR, INT),
     syscall!(close_range, INT, INT, INT),
-    syscall!(openat2, INT, STR, ADDR, INT),
+    syscall!(openat2, INT, BYTES, ADDR, INT),
     syscall!(pidfd_getfd, INT, INT, INT),
-    syscall!(faccessat2, INT, STR, INT, INT),
+    syscall!(faccessat2, INT, BYTES, INT, INT),
     syscall!(process_madvise, INT, ADDR, INT, INT, INT),
     syscall!(epoll_pwait2, INT, ADDR, INT, ADDR, ADDR, INT),
-    syscall!(mount_setattr, INT, STR, INT, ADDR, INT),
+    syscall!(mount_setattr, INT, BYTES, INT, ADDR, INT),
     syscall!(quotactl_fd, INT, INT, INT, ADDR),
     syscall!(landlock_create_ruleset, ADDR, INT, INT),
     syscall!(landlock_add_rule, INT, INT, ADDR, INT),


### PR DESCRIPTION
Dear author,

I wanted to let you know about a bug that we've encountered and need to address in our code. Currently, there is an issue when attempting to read memory from other processes using ptrace, which is causing errors and disruptions.

Here are the specific details of the bug:

Some system calls return non-negative values, but the final output string parameter is empty. This inconsistency is leading to unexpected behavior within our application.

The read_string function in mod.rs contains a bug. It stops reading when it encounters a null character (\0) in memory. However, it's important to note that not all data in memory is necessarily a string. For example, the write syscall may write bytes to devices instead of a C string.

To resolve these issues, I suggest the following solution:

Modify the read_string function to read a sequence of bytes instead of assuming it always contains a string.

For your reference, I have attached screenshots highlighting the problem areas:

![image](https://github.com/JakWai01/lurk/assets/72367456/91d1b461-c08b-4732-97f7-7626eec74dc4)

In `src/arch/mode.rs`

![image](https://github.com/JakWai01/lurk/assets/72367456/e217c549-f6eb-4cec-a784-0ff71aa36e6a)


Thank you for your attention and commitment to delivering exceptional app.

Best regards,