### PR TITLE
Fix SIGCHLD handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ impl Tracer {
                     // Therefor issue a PTRACE_SYSCALL request to the parent to continue execution.
                     // This is also important if we trace without the following forks option.
                     if signal == Signal::SIGCHLD {
-                        ptrace::cont(pid, signal)?;
+                        self.issue_ptrace_syscall_request(pid, Some(signal))?;
                         continue;
                     }
 


### PR DESCRIPTION
Using ptrace::cont will skip some or a lot of syscalls depending on scenario. ptrace::syscall should be used here.

Reproducer: 

```c
#include <unistd.h>
#include <stdlib.h>
#include <sys/wait.h>

int main() {
    if (0 == fork()) {
        exit(0);
    } else {
        wait(NULL);
        fork();
    }
    return 0;
}
// gcc reproducer.c -o reproducer
```

To reproduce, run ` cargo run -- ./reproducer` and compare the output with or without  this PR. Without this PR, the final clone syscall doesn't show.

```
[283807] munmap(0x7FFFF7F63000, 379247) = 0
[283807] clone(0x1200011, 0) = 0x454A0
[283807] wait4(4294967295, 0, 0, 0x0) = 0x454A0
[283807] clone(0x1200011, 0) = 0x454A1 # This line only shows with this PR
[283807] exit_group(0) = ?
```

Actually I [fixed a similar bug in tracexec](https://github.com/kxxt/tracexec/commit/f895a6adfaaba2c7a093d5a62161cc389b5b2506), which is a project that takes some inspiration from lurk,  but I forgot to contribute it back to lurk at that time. 

Fixes #32