### PR TITLE
chore(ci): do not upload binary when release is triggered manually

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -16,6 +16,7 @@ jobs:
           command: build
           args: --release
       - name: Upload to release
+        if: github.event_name != 'workflow_dispatch'
         uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: lurk


### PR DESCRIPTION
Sometimes we bump the crate version (in `Cargo.toml`) after we create the GitHub release. This results in `crates.io` step in CI failing with the following error:

```
Caused by:
  the remote server responded with an error (status 400 Bad Request): crate version `0.3.5` is already uploaded
```

<https://github.com/JakWai01/lurk/actions/runs/10026789833/job/27711561490>

This can be solved by manually triggering the workflow again. However, in that case `Linux` step fails due to `workflow_dispatch`:

```
'refs/heads/main'; this action only supports events from tag or release by default; see <https://github.com/taiki-e/create-gh-release-action#supported-events> for more
```

<https://github.com/JakWai01/lurk/actions/runs/10092987365/job/27907767844>

This PR solves this edge case by skipping running the `Linux` step when the release is triggered manually.
