### PR TITLE
Fix execve not printing arguments

### DIFF
--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -311,6 +311,7 @@ macro_rules! syscall {
 const ADDR: Option<SyscallArgType> = Some(SyscallArgType::Addr);
 const INT: Option<SyscallArgType> = Some(SyscallArgType::Int);
 const STR: Option<SyscallArgType> = Some(SyscallArgType::Str);
+const VEC_STR: Option<SyscallArgType> = Some(SyscallArgType::VecStr);
 
 pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC
@@ -426,7 +427,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // PROCESS
     syscall!(vfork, ADDR),
     // PROCESS
-    syscall!(execve, STR, STR, STR),
+    syscall!(execve, STR, VEC_STR, VEC_STR),
     // PROCESS
     syscall!(exit, INT),
     // PROCESS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,10 +233,17 @@ impl<W: Write> Tracer<W> {
 
                     // We only want to log regular syscalls on exit
                     if let Some(syscall_start_time) = start_times.get_mut(&pid) {
+                        let (syscall_number, _) = self.parse_register_data(pid)?;
                         if event == 2 {
-                            self.log_standard_syscall(pid, *syscall_start_time, timestamp)?;
+                            if syscall_number != Sysno::execve {
+                                self.log_standard_syscall(pid, *syscall_start_time, timestamp)?;
+                            }
                             *syscall_start_time = None;
                         } else {
+                            // execve arguments are already gone at exit so we log on enter
+                            if syscall_number == Sysno::execve {
+                                self.log_standard_syscall(pid, *syscall_start_time, timestamp)?;
+                            }
                             *syscall_start_time = timestamp;
                         }
                     } else {
@@ -374,6 +381,7 @@ impl<W: Write> Tracer<W> {
         // -38 is ENOSYS which is put into RAX as a default return value by the kernel's syscall entry code.
         // In order to not pollute the summary with this false positive, avoid exit-family syscalls from being counted (same behaviour as strace).
         let ret_code = match syscall_number {
+            Sysno::execve => RetCode::from_raw(0),
             Sysno::exit | Sysno::exit_group => RetCode::from_raw(0),
             _ => {
                 #[cfg(target_arch = "x86_64")]

--- a/src/syscall_info.rs
+++ b/src/syscall_info.rs
@@ -117,6 +117,7 @@ impl Serialize for SyscallArgs {
                 SyscallArg::Int(v) => serde_json::to_value(v).unwrap(),
                 SyscallArg::Str(v) => serde_json::to_value(v).unwrap(),
                 SyscallArg::Addr(v) => Value::String(format!("{v:#x}")),
+                SyscallArg::VecStr(v) => serde_json::to_value(v).unwrap(),
             };
             seq.serialize_element(&value)?;
         }
@@ -161,6 +162,7 @@ impl Display for RetCode {
 pub enum SyscallArg {
     Int(i64),
     Str(String),
+    VecStr(Vec<String>),
     Addr(usize),
 }
 
@@ -177,6 +179,14 @@ impl SyscallArg {
                 write!(f, "{value}")
             }
             Self::Addr(v) => write!(f, "{v:#X}"),
+            Self::VecStr(v) => {
+                let out = format!("{:?}", v);
+                let value = match string_limit {
+                    Some(width) => trim_str(&out, width),
+                    None => out.into(),
+                };
+                write!(f, "{value}")
+            },
         }
     }
 }


### PR DESCRIPTION
Execve arguments are not printed becase syscalls are logged only on exit, closes #30, #38.
This code it bit of a hack, there is a duplicated call to parse_register_data and the ret code of exit is ignored.