### PR TITLE
Remove ADDR argument from sched_yield

### DIFF
--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -360,7 +360,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(pipe, INT, INT),
     // DESC
     syscall!(select, INT, ADDR, ADDR, ADDR, ADDR),
-    syscall!(sched_yield, ADDR),
+    syscall!(sched_yield),
     // MEMORY
     syscall!(mremap, ADDR, INT, INT, INT, ADDR),
     // MEMORY


### PR DESCRIPTION
Since [`sched_yield` doesn't have an argument](https://www.man7.org/linux/man-pages/man2/sched_yield.2.html), lurk shouldn't (try to) display an argument for it.