### PR TITLE
Bump `nix` to fix AArch64 musl build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,19 +226,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "linux-personality"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b75a6f16d41feaade8e14b844d8a1f92c4b238543c80e8403dd27d9f86993c"
-dependencies = [
- "bitflags",
- "libc",
-]
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"
@@ -272,7 +262,6 @@ dependencies = [
  "comfy-table",
  "console",
  "libc",
- "linux-personality",
  "nix",
  "regex",
  "serde",
@@ -289,9 +278,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,7 @@ clap = { version = "4", features = ["derive"] }
 comfy-table = "7"
 console = "0.15.8"
 libc = "0.2"
-linux-personality = "2"
-nix = { version = "0.29", features = ["ptrace", "signal"] }
+nix = { version = "0.30.1", features = ["personality", "ptrace", "signal"] }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ use comfy_table::presets::UTF8_BORDERS_ONLY;
 use comfy_table::CellAlignment::Right;
 use comfy_table::{Cell, ContentArrangement, Row, Table};
 use libc::user_regs_struct;
-use linux_personality::{personality, Personality};
+use nix::sys::personality::{self, Persona};
 use nix::sys::ptrace::{self, Event};
 use nix::sys::signal::Signal;
 use nix::sys::wait::{wait, WaitStatus};
@@ -484,7 +484,7 @@ impl<W: Write> Tracer<W> {
 
 pub fn run_tracee(command: &[String], envs: &[String], username: &Option<String>) -> Result<()> {
     ptrace::traceme()?;
-    personality(Personality::ADDR_NO_RANDOMIZE)
+    personality::set(Persona::ADDR_NO_RANDOMIZE)
         .map_err(|_| anyhow!("Unable to set ADDR_NO_RANDOMIZE"))?;
     let mut binary = command
         .first()


### PR DESCRIPTION
Updating to the latest `nix` pulls in nix-rust/nix#2510, which fixes the `aarch64-unknown-linux-musl` build failing with:

```
error[E0425]: cannot find function `getregs` in module `ptrace`
   --> src/lib.rs:448:17
    |
448 |         ptrace::getregs(pid).map_err(|_| anyhow!("Unable to get registers from tracee {}", pid))
    |                 ^^^^^^^ not found in `ptrace`
```
While we're at it, drop `linux-personality` and use the `nix` feature instead.