### PR TITLE
Reworked ptrace tracing loop v2

### DIFF
--- a/examples/tracer.rs
+++ b/examples/tracer.rs
@@ -1,19 +1,12 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use console::Style;
-use lurk_cli::{args::Args, style::StyleConfig, Tracer};
-use nix::unistd::{fork, ForkResult};
+use lurk_cli::{args::Args, spawn_tracee, style::StyleConfig, Tracer};
 use std::io;
 
 fn main() -> Result<()> {
     let command = String::from("/usr/bin/ls");
 
-    let pid = match unsafe { fork() } {
-        Ok(ForkResult::Child) => {
-            return lurk_cli::run_tracee(&[command], &[], &None);
-        }
-        Ok(ForkResult::Parent { child }) => child,
-        Err(err) => bail!("fork() failed: {err}"),
-    };
+    let pid = spawn_tracee(&[command], &[], &None)?;
 
     let args = Args::default();
     let output = io::stdout();
@@ -26,5 +19,7 @@ fn main() -> Result<()> {
         use_colors: true,
     };
 
-    Tracer::new(pid, args, output, style)?.run_tracer()
+    let mut tracer = Tracer::new(pid, args, output, style)?;
+    tracer.set_seized_spawn();
+    tracer.run_tracer()
 }

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -1,12 +1,22 @@
+#![allow(
+    clippy::cast_sign_loss,
+    clippy::type_complexity,
+    clippy::used_underscore_binding
+)]
+
 use crate::arch::SyscallArgType;
+#[cfg(target_arch = "aarch64")]
 use libc::{c_ulonglong, user_regs_struct};
 use std::ops::Index;
 use syscalls::aarch64::Sysno;
+#[cfg(target_arch = "aarch64")]
 use syscalls::SysnoSet;
 
 #[allow(clippy::enum_glob_use)]
+#[cfg(target_arch = "aarch64")]
 use syscalls::aarch64::Sysno::*;
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_DESC: SysnoSet = SysnoSet::new(&[
     // strace/src/linux/64/syscallent.h
     fsetxattr,
@@ -124,6 +134,7 @@ pub static TRACE_DESC: SysnoSet = SysnoSet::new(&[
     fchmodat2,
 ]);
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_FILE: SysnoSet = SysnoSet::new(&[
     // strace/src/linux/64/syscallent.h
     setxattr,
@@ -179,10 +190,12 @@ pub static TRACE_FILE: SysnoSet = SysnoSet::new(&[
     fchmodat2,
 ]);
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_IPC: SysnoSet = SysnoSet::new(&[
     msgget, msgctl, msgrcv, msgsnd, semget, semctl, semtimedop, semop, shmget, shmctl, shmat, shmdt,
 ]);
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_NETWORK: SysnoSet = SysnoSet::new(&[
     sendfile,
     socket,
@@ -205,6 +218,7 @@ pub static TRACE_NETWORK: SysnoSet = SysnoSet::new(&[
     sendmmsg,
 ]);
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_PROCESS: SysnoSet = SysnoSet::new(&[
     // strace/src/linux/64/syscallent.h
     exit,
@@ -224,13 +238,10 @@ pub static TRACE_PROCESS: SysnoSet = SysnoSet::new(&[
     clone3,
 ]);
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_SIGNAL: SysnoSet = SysnoSet::new(&[
     // strace/src/linux/64/syscallent.h
-    statfs,
-    fstatfs,
     signalfd4,
-    fstatat,
-    fstat,
     kill,
     tkill,
     tgkill,
@@ -242,15 +253,13 @@ pub static TRACE_SIGNAL: SysnoSet = SysnoSet::new(&[
     rt_sigtimedwait,
     rt_sigqueueinfo,
     rt_sigreturn,
-    execve,
     rt_tgsigqueueinfo,
-    execveat,
-    statx,
     // strace/src/linux/generic/syscallent-common.h
     pidfd_send_signal,
     io_uring_enter,
 ]);
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_MEMORY: SysnoSet = SysnoSet::new(&[
     // strace/src/linux/64/syscallent.h
     io_setup,
@@ -283,46 +292,32 @@ pub static TRACE_MEMORY: SysnoSet = SysnoSet::new(&[
     map_shadow_stack,
 ]);
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_STAT: SysnoSet = SysnoSet::new(&[fstatat, fstat, statx]);
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_LSTAT: SysnoSet = SysnoSet::new(&[]);
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_FSTAT: SysnoSet = SysnoSet::new(&[fstatat, fstat, statx]);
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_STAT_LIKE: SysnoSet = SysnoSet::new(&[fstatat, fstat, statx]);
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_STATFS: SysnoSet = SysnoSet::new(&[statfs, fstatfs]);
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_FSTATFS: SysnoSet = SysnoSet::new(&[fstatfs]);
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_STATFS_LIKE: SysnoSet = SysnoSet::new(&[statfs, fstatfs]);
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_PURE: SysnoSet =
     SysnoSet::new(&[getpid, getppid, getuid, geteuid, getgid, getegid, gettid]);
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_CREDS: SysnoSet = SysnoSet::new(&[
-    capget,
-    capset,
-    clock_settime,
-    clock_gettime,
-    clock_getres,
-    setregid,
-    setgid,
-    setreuid,
-    setuid,
-    setresuid,
-    getresuid,
-    setresgid,
-    getresgid,
-    setfsuid,
-    setfsgid,
-    getgroups,
-    setgroups,
-    prctl,
-    gettimeofday,
-    settimeofday,
-    adjtimex,
-    getuid,
-    geteuid,
-    getgid,
-    getegid,
-    clock_adjtime,
+    capget, capset, setregid, setgid, setreuid, setuid, setresuid, getresuid, setresgid, getresgid,
+    setfsuid, setfsgid, getgroups, setgroups, prctl, getuid, geteuid, getgid, getegid,
 ]);
 
+#[cfg(target_arch = "aarch64")]
 pub static TRACE_CLOCK: SysnoSet = SysnoSet::new(&[
     clock_settime,
     clock_gettime,
@@ -361,6 +356,13 @@ const ADDR: Option<SyscallArgType> = Some(SyscallArgType::Addr);
 const INT: Option<SyscallArgType> = Some(SyscallArgType::Int);
 const STR: Option<SyscallArgType> = Some(SyscallArgType::Str);
 const STRV: Option<SyscallArgType> = Some(SyscallArgType::StrArray);
+const STRVS: Option<SyscallArgType> = Some(SyscallArgType::StrArraySummary);
+const IN1: Option<SyscallArgType> = Some(SyscallArgType::InputBuffer(1));
+const IN2: Option<SyscallArgType> = Some(SyscallArgType::InputBuffer(2));
+const IN3: Option<SyscallArgType> = Some(SyscallArgType::InputBuffer(3));
+const OUT1: Option<SyscallArgType> = Some(SyscallArgType::OutputBuffer(1));
+const OUT2: Option<SyscallArgType> = Some(SyscallArgType::OutputBuffer(2));
+const OUT3: Option<SyscallArgType> = Some(SyscallArgType::OutputBuffer(3));
 
 pub struct Aarch64Syscalls {
     _0: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 244],
@@ -395,20 +397,20 @@ pub static SYSCALLS: Aarch64Syscalls = Aarch64Syscalls {
         syscall!(io_submit, INT, INT, ADDR),
         syscall!(io_cancel, INT, ADDR, ADDR),
         syscall!(io_getevents, INT, INT, INT, ADDR, ADDR),
-        syscall!(setxattr, STR, STR, ADDR, INT, INT),
-        syscall!(lsetxattr, STR, STR, ADDR, INT, INT),
-        syscall!(fsetxattr, INT, STR, ADDR, INT, INT),
-        syscall!(getxattr, STR, STR, ADDR, INT),
-        syscall!(lgetxattr, STR, STR, ADDR, INT),
-        syscall!(fgetxattr, INT, STR, ADDR, INT),
-        syscall!(listxattr, STR, STR, INT),
-        syscall!(llistxattr, STR, STR, INT),
-        syscall!(flistxattr, INT, STR, INT),
+        syscall!(setxattr, STR, STR, IN3, INT, INT),
+        syscall!(lsetxattr, STR, STR, IN3, INT, INT),
+        syscall!(fsetxattr, INT, STR, IN3, INT, INT),
+        syscall!(getxattr, STR, STR, OUT3, INT),
+        syscall!(lgetxattr, STR, STR, OUT3, INT),
+        syscall!(fgetxattr, INT, STR, OUT3, INT),
+        syscall!(listxattr, STR, OUT2, INT),
+        syscall!(llistxattr, STR, OUT2, INT),
+        syscall!(flistxattr, INT, OUT2, INT),
         syscall!(removexattr, STR, STR),
         syscall!(lremovexattr, STR, STR),
         syscall!(fremovexattr, INT, STR),
-        syscall!(getcwd, STR, INT),
-        syscall!(lookup_dcookie, INT, STR, INT),
+        syscall!(getcwd, OUT1, INT),
+        syscall!(lookup_dcookie, INT, OUT2, INT),
         syscall!(eventfd2, INT, INT),
         syscall!(epoll_create1, INT),
         syscall!(epoll_ctl, INT, INT, INT, ADDR),
@@ -453,12 +455,12 @@ pub static SYSCALLS: Aarch64Syscalls = Aarch64Syscalls {
         syscall!(quotactl, INT, STR, INT, ADDR),
         syscall!(getdents64, INT, ADDR, INT),
         syscall!(lseek, INT, INT, INT),
-        syscall!(read, INT, STR, INT),
-        syscall!(write, INT, STR, INT),
+        syscall!(read, INT, OUT2, INT),
+        syscall!(write, INT, IN2, INT),
         syscall!(readv, INT, ADDR, INT),
         syscall!(writev, INT, ADDR, INT),
-        syscall!(pread64, INT, STR, INT, INT),
-        syscall!(pwrite64, INT, STR, INT, INT),
+        syscall!(pread64, INT, OUT2, INT, INT),
+        syscall!(pwrite64, INT, IN2, INT, INT),
         syscall!(preadv, INT, ADDR, INT, INT, INT),
         syscall!(pwritev, INT, ADDR, INT, INT, INT),
         syscall!(sendfile, INT, INT, ADDR, INT),
@@ -468,7 +470,7 @@ pub static SYSCALLS: Aarch64Syscalls = Aarch64Syscalls {
         syscall!(vmsplice, INT, ADDR, INT, INT),
         syscall!(splice, INT, ADDR, INT, ADDR, INT, INT),
         syscall!(tee, INT, INT, INT, INT),
-        syscall!(readlinkat, INT, STR, STR, INT),
+        syscall!(readlinkat, INT, STR, OUT3, INT),
         syscall!(fstatat, INT, STR, ADDR, INT),
         syscall!(fstat, INT, ADDR),
         syscall!(sync),
@@ -506,7 +508,7 @@ pub static SYSCALLS: Aarch64Syscalls = Aarch64Syscalls {
         syscall!(clock_gettime, INT, ADDR),
         syscall!(clock_getres, INT, ADDR),
         syscall!(clock_nanosleep, INT, INT, ADDR, ADDR),
-        syscall!(syslog, INT, STR, INT),
+        syscall!(syslog, INT, OUT2, INT),
         syscall!(ptrace, INT, INT, INT, INT),
         syscall!(sched_setparam, INT, ADDR),
         syscall!(sched_setscheduler, INT, INT, ADDR),
@@ -551,8 +553,8 @@ pub static SYSCALLS: Aarch64Syscalls = Aarch64Syscalls {
         syscall!(getgroups, INT, ADDR),
         syscall!(setgroups, INT, ADDR),
         syscall!(uname, ADDR),
-        syscall!(sethostname, STR, INT),
-        syscall!(setdomainname, STR, INT),
+        syscall!(sethostname, IN1, INT),
+        syscall!(setdomainname, IN1, INT),
         syscall!(getrlimit, INT, ADDR),
         syscall!(setrlimit, INT, ADDR),
         syscall!(getrusage, INT, ADDR),
@@ -572,8 +574,8 @@ pub static SYSCALLS: Aarch64Syscalls = Aarch64Syscalls {
         syscall!(sysinfo, ADDR),
         syscall!(mq_open, STR, INT, INT, ADDR),
         syscall!(mq_unlink, STR),
-        syscall!(mq_timedsend, INT, STR, INT, INT, ADDR),
-        syscall!(mq_timedreceive, INT, STR, INT, ADDR, ADDR),
+        syscall!(mq_timedsend, INT, IN2, INT, INT, ADDR),
+        syscall!(mq_timedreceive, INT, OUT2, INT, ADDR, ADDR),
         syscall!(mq_notify, INT, ADDR),
         syscall!(mq_getsetattr, INT, ADDR, ADDR),
         syscall!(msgget, INT, INT),
@@ -596,10 +598,10 @@ pub static SYSCALLS: Aarch64Syscalls = Aarch64Syscalls {
         syscall!(connect, INT, ADDR, INT),
         syscall!(getsockname, INT, ADDR, ADDR),
         syscall!(getpeername, INT, ADDR, ADDR),
-        syscall!(sendto, INT, ADDR, INT, INT, ADDR, INT),
-        syscall!(recvfrom, INT, ADDR, INT, INT, ADDR, ADDR),
-        syscall!(setsockopt, INT, INT, INT, STR, INT),
-        syscall!(getsockopt, INT, INT, INT, STR, ADDR),
+        syscall!(sendto, INT, IN2, INT, INT, ADDR, INT),
+        syscall!(recvfrom, INT, OUT2, INT, INT, ADDR, ADDR),
+        syscall!(setsockopt, INT, INT, INT, ADDR, INT),
+        syscall!(getsockopt, INT, INT, INT, ADDR, ADDR),
         syscall!(shutdown, INT, INT),
         syscall!(sendmsg, INT, ADDR, INT),
         syscall!(recvmsg, INT, ADDR, INT),
@@ -607,11 +609,11 @@ pub static SYSCALLS: Aarch64Syscalls = Aarch64Syscalls {
         syscall!(brk, INT),
         syscall!(munmap, INT, INT),
         syscall!(mremap, INT, INT, INT, INT, INT),
-        syscall!(add_key, STR, STR, ADDR, INT, INT),
+        syscall!(add_key, STR, STR, IN3, INT, INT),
         syscall!(request_key, STR, STR, STR, INT),
         syscall!(keyctl, INT, INT, INT, INT, INT),
         syscall!(clone, INT, INT, ADDR, INT, ADDR),
-        syscall!(execve, STR, STRV, STRV),
+        syscall!(execve, STR, STRV, STRVS),
         syscall!(mmap, ADDR, INT, INT, INT, INT, INT),
         syscall!(fadvise64, INT, INT, INT, INT),
         syscall!(swapon, STR, INT),
@@ -654,10 +656,10 @@ pub static SYSCALLS: Aarch64Syscalls = Aarch64Syscalls {
         syscall!(sched_getattr, INT, ADDR, INT, INT),
         syscall!(renameat2, INT, STR, INT, STR, INT),
         syscall!(seccomp, INT, INT, ADDR),
-        syscall!(getrandom, STR, INT, INT),
+        syscall!(getrandom, OUT1, INT, INT),
         syscall!(memfd_create, STR, INT),
         syscall!(bpf, INT, ADDR, INT),
-        syscall!(execveat, INT, STR, STRV, STRV, INT),
+        syscall!(execveat, INT, STR, STRV, STRVS, INT),
         syscall!(userfaultfd, INT),
         syscall!(membarrier, INT, INT, INT),
         syscall!(mlock2, INT, INT, INT),
@@ -705,6 +707,7 @@ pub static SYSCALLS: Aarch64Syscalls = Aarch64Syscalls {
     ],
 };
 
+#[cfg(target_arch = "aarch64")]
 pub fn get_arg_value(registers: user_regs_struct, i: usize) -> c_ulonglong {
     match i {
         0 => registers.regs[0],

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -1,5 +1,4 @@
 use crate::syscall_info::{SyscallArg, SyscallArgs};
-use byteorder::{LittleEndian, WriteBytesExt};
 use libc::{c_long, c_ulonglong, user_regs_struct};
 use nix::sys::ptrace;
 use nix::sys::ptrace::Options;
@@ -65,124 +64,250 @@ pub enum SyscallArgType {
     Str,
     // Array of strings, e.g. argv or envp
     StrArray,
+    // String array that must not be copied into trace output (e.g. envp).
+    StrArraySummary,
+    // Input/output buffers.  The contained index points to the length arg.
+    InputBuffer(usize),
+    OutputBuffer(usize),
     // Address can be used to represent *statbuf
     Addr,
 }
 
+const MAX_CAPTURE_BYTES: usize = 64 * 1024;
+const MAX_ARRAY_ELEMENTS: usize = 1024;
+
 pub fn read_string(pid: Pid, address: c_ulonglong) -> String {
-    let mut string = String::new();
-    // Move 8 bytes up each time for next read.
-    let mut count = 0;
-    let word_size = 8;
+    read_string_limited(pid, address, MAX_CAPTURE_BYTES)
+}
 
-    'done: loop {
-        let address = unsafe { (address as *mut c_void).offset(count) };
-
-        let res: c_long = match ptrace::read(pid, address) {
-            Ok(c_long) => c_long,
-            Err(_) => {
-                // If we can't read the memory at the address, return the pointer
-                // as a hex string so callers can still see a useful value.
-                return format!("{:#x}", address as usize);
-            }
-        };
-
-        let mut bytes: Vec<u8> = vec![];
-        bytes.write_i64::<LittleEndian>(res).unwrap_or_else(|err| {
-            panic!("Failed to write {res} as i64 LittleEndian: {err}");
-        });
-        for b in bytes {
-            if b == 0 {
-                break 'done;
-            }
-            string.push(b as char);
-        }
-
-        count += word_size;
+pub fn read_string_limited(pid: Pid, address: c_ulonglong, limit: usize) -> String {
+    if address == 0 {
+        return "NULL".to_owned();
     }
 
-    string
+    let mut bytes = Vec::new();
+    let limit = limit.min(MAX_CAPTURE_BYTES);
+    while bytes.len() < limit {
+        let read_address = address.wrapping_add(bytes.len() as u64) as usize as *mut c_void;
+        let word = match ptrace::read(pid, read_address) {
+            Ok(word) => word,
+            Err(_) if bytes.is_empty() => return format!("{address:#x}"),
+            Err(_) => break,
+        };
+        for byte in word.to_ne_bytes() {
+            if byte == 0 || bytes.len() == limit {
+                return String::from_utf8_lossy(&bytes).into_owned();
+            }
+            bytes.push(byte);
+        }
+    }
+
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+pub fn ptrace_options(follow_forks: bool) -> Options {
+    let mut options =
+        Options::PTRACE_O_TRACESYSGOOD | Options::PTRACE_O_TRACEEXIT | Options::PTRACE_O_TRACEEXEC;
+    if follow_forks {
+        options |= Options::PTRACE_O_TRACEFORK
+            | Options::PTRACE_O_TRACEVFORK
+            | Options::PTRACE_O_TRACECLONE;
+    }
+    options
 }
 
 pub fn ptrace_init_options(pid: Pid) -> nix::Result<()> {
-    ptrace::setoptions(
-        pid,
-        Options::PTRACE_O_TRACESYSGOOD | Options::PTRACE_O_TRACEEXIT | Options::PTRACE_O_TRACEEXEC,
-    )
+    ptrace::setoptions(pid, ptrace_options(false))
 }
 
 pub fn ptrace_init_options_fork(pid: Pid) -> nix::Result<()> {
-    ptrace::setoptions(
-        pid,
-        Options::PTRACE_O_TRACESYSGOOD
-            | Options::PTRACE_O_TRACEEXIT
-            | Options::PTRACE_O_TRACEEXEC
-            | Options::PTRACE_O_TRACEFORK
-            | Options::PTRACE_O_TRACEVFORK
-            | Options::PTRACE_O_TRACECLONE,
-    )
+    ptrace::setoptions(pid, ptrace_options(true))
 }
 
 #[allow(clippy::cast_sign_loss)]
 #[must_use]
 // SAFTEY: In get_register_data we make sure that the syscall number will never be negative.
 pub fn parse_args(pid: Pid, syscall: Sysno, registers: user_regs_struct) -> SyscallArgs {
+    parse_entry_args(pid, syscall, registers, None)
+}
+
+pub fn register_args(registers: user_regs_struct) -> [u64; 6] {
+    std::array::from_fn(|idx| get_arg_value(registers, idx))
+}
+
+pub fn unknown_args(registers: user_regs_struct) -> SyscallArgs {
+    unknown_args_from_values(register_args(registers))
+}
+
+pub fn unknown_args_from_values(values: [u64; 6]) -> SyscallArgs {
+    SyscallArgs(
+        values
+            .into_iter()
+            .map(|value| SyscallArg::Addr(value as usize))
+            .collect(),
+    )
+}
+
+pub fn parse_entry_args(
+    pid: Pid,
+    syscall: Sysno,
+    registers: user_regs_struct,
+    string_limit: Option<usize>,
+) -> SyscallArgs {
+    let values = register_args(registers);
+    parse_args_from_values(pid, syscall, values, string_limit, false, 0)
+}
+
+pub fn parse_exit_args(
+    pid: Pid,
+    syscall: Sysno,
+    registers: user_regs_struct,
+    string_limit: Option<usize>,
+    result: i64,
+    entry_args: &SyscallArgs,
+) -> SyscallArgs {
+    let values = register_args(registers);
+    let mut args = entry_args.clone();
+    let syscall_index = usize::try_from(syscall.id()).expect("syscall IDs are non-negative");
+    let Some((_, types)) = SYSCALLS.get(syscall_index).and_then(Option::as_ref) else {
+        return args;
+    };
+    for (idx, arg_type) in types.iter().enumerate() {
+        if let Some(arg_type @ SyscallArgType::OutputBuffer(_)) = *arg_type {
+            if let Some(slot) = args.0.get_mut(idx) {
+                *slot = map_arg(pid, values, idx, arg_type, string_limit, true, result);
+            }
+        }
+    }
+    args
+}
+
+fn parse_args_from_values(
+    pid: Pid,
+    syscall: Sysno,
+    values: [u64; 6],
+    string_limit: Option<usize>,
+    at_exit: bool,
+    result: i64,
+) -> SyscallArgs {
+    let syscall_index = usize::try_from(syscall.id()).expect("syscall IDs are non-negative");
     SYSCALLS
-        .get(syscall.id() as usize)
+        .get(syscall_index)
         .and_then(|option| option.as_ref())
         .map_or_else(
             || SyscallArgs(vec![]),
             |(_, args)| {
                 SyscallArgs(
                     args.iter()
-                        .filter_map(Option::as_ref)
                         .enumerate()
-                        .map(|(idx, arg_type)| map_arg(pid, registers, idx, *arg_type))
+                        .filter_map(|(idx, arg_type)| {
+                            arg_type.map(|arg_type| {
+                                map_arg(pid, values, idx, arg_type, string_limit, at_exit, result)
+                            })
+                        })
                         .collect(),
                 )
             },
         )
 }
 
-fn map_arg(pid: Pid, registers: user_regs_struct, idx: usize, arg: SyscallArgType) -> SyscallArg {
-    let value = get_arg_value(registers, idx);
+fn map_arg(
+    pid: Pid,
+    values: [u64; 6],
+    idx: usize,
+    arg: SyscallArgType,
+    string_limit: Option<usize>,
+    at_exit: bool,
+    result: i64,
+) -> SyscallArg {
+    let value = values[idx];
+    let capture_limit = string_limit
+        .map_or(MAX_CAPTURE_BYTES, |limit| limit.saturating_add(1))
+        .min(MAX_CAPTURE_BYTES);
     match arg {
-        SyscallArgType::Int => SyscallArg::Int(value as i64),
-        SyscallArgType::Str => SyscallArg::Str(read_string(pid, value)),
-        SyscallArgType::StrArray => {
-            SyscallArg::StrVec(read_string_array(pid, value), Some(value as usize))
+        SyscallArgType::Int => {
+            let narrow = u32::try_from(value).ok();
+            let value = narrow
+                .filter(|value| *value >= u32::MAX - 4095)
+                .map_or(value as i64, |value| i64::from(value as i32));
+            SyscallArg::Int(value)
         }
-        SyscallArgType::Addr => SyscallArg::Addr(value as usize),
+        SyscallArgType::Str => SyscallArg::Str(read_string_limited(pid, value, capture_limit)),
+        SyscallArgType::StrArray => SyscallArg::StrVec(
+            read_string_array_limited(pid, value, capture_limit),
+            Some(value as usize),
+        ),
+        SyscallArgType::StrArraySummary => {
+            SyscallArg::StrArraySummary(read_string_array_count(pid, value), value as usize)
+        }
+        SyscallArgType::InputBuffer(length_idx) if value != 0 => SyscallArg::Bytes(read_buffer(
+            pid,
+            value,
+            values[length_idx] as usize,
+            capture_limit,
+        )),
+        SyscallArgType::InputBuffer(_) => SyscallArg::Addr(0),
+        SyscallArgType::OutputBuffer(length_idx) if at_exit && result >= 0 => {
+            let length = (values[length_idx] as usize)
+                .min(usize::try_from(result).expect("non-negative syscall result"));
+            if value == 0 {
+                SyscallArg::Addr(0)
+            } else {
+                SyscallArg::Bytes(read_buffer(pid, value, length, capture_limit))
+            }
+        }
+        SyscallArgType::OutputBuffer(_) | SyscallArgType::Addr => SyscallArg::Addr(value as usize),
     }
 }
 
+fn read_buffer(pid: Pid, address: u64, length: usize, capture_limit: usize) -> Vec<u8> {
+    let length = length.min(capture_limit).min(MAX_CAPTURE_BYTES);
+    let mut bytes = Vec::with_capacity(length);
+    let word_size = std::mem::size_of::<c_long>();
+    for offset in (0..length).step_by(word_size) {
+        let read_address = address.wrapping_add(offset as u64) as usize as *mut c_void;
+        let Ok(word) = ptrace::read(pid, read_address) else {
+            break;
+        };
+        let remaining = length - bytes.len();
+        bytes.extend_from_slice(&word.to_ne_bytes()[..remaining.min(word_size)]);
+    }
+    bytes
+}
+
 pub fn read_string_array(pid: Pid, address: c_ulonglong) -> Vec<String> {
+    read_string_array_limited(pid, address, MAX_CAPTURE_BYTES)
+}
+
+pub fn read_string_array_limited(
+    pid: Pid,
+    address: c_ulonglong,
+    string_limit: usize,
+) -> Vec<String> {
     let mut vec = Vec::new();
     if address == 0 {
         return vec;
     }
 
-    // pointer size on x86_64 is 8 bytes; read pointers until NULL
-    let mut offset = 0isize;
     // safety limit to avoid infinite loops on corrupt pointers
-    for _ in 0..1024 {
-        let ptr_addr = unsafe { (address as *mut c_void).offset(offset) };
+    let mut remaining = MAX_CAPTURE_BYTES;
+    for offset in 0..MAX_ARRAY_ELEMENTS {
+        let ptr_addr = address.wrapping_add((offset * std::mem::size_of::<usize>()) as u64) as usize
+            as *mut c_void;
         let res: c_long = match ptrace::read(pid, ptr_addr) {
             Ok(v) => v,
             Err(_) => break,
         };
-        let mut bytes: Vec<u8> = vec![];
-
-        bytes.write_i64::<LittleEndian>(res).ok();
-        let mut ptr_value: c_ulonglong = 0;
-        for (i, b) in bytes.iter().enumerate() {
-            ptr_value |= c_ulonglong::from(*b) << (i * 8);
-        }
+        let ptr_value = c_ulonglong::from_ne_bytes(res.to_ne_bytes());
         if ptr_value == 0 {
             break;
         }
-        vec.push(read_string(pid, ptr_value));
-        offset += std::mem::size_of::<c_ulonglong>() as isize;
+        if remaining == 0 {
+            break;
+        }
+        let value = read_string_limited(pid, ptr_value, string_limit.min(remaining));
+        remaining = remaining.saturating_sub(value.len().saturating_add(1));
+        vec.push(value);
     }
 
     vec
@@ -197,25 +322,18 @@ pub fn read_string_array_count(pid: Pid, address: c_ulonglong) -> usize {
     }
 
     let mut count = 0usize;
-    let mut offset = 0isize;
-    for _ in 0..1024 {
-        let ptr_addr = unsafe { (address as *mut c_void).offset(offset) };
+    for offset in 0..MAX_ARRAY_ELEMENTS {
+        let ptr_addr = address.wrapping_add((offset * std::mem::size_of::<usize>()) as u64) as usize
+            as *mut c_void;
         let res: c_long = match ptrace::read(pid, ptr_addr) {
             Ok(v) => v,
             Err(_) => break,
         };
-        // reconstruct pointer value from bytes
-        let mut bytes: Vec<u8> = vec![];
-        bytes.write_i64::<LittleEndian>(res).ok();
-        let mut ptr_value: c_ulonglong = 0;
-        for (i, b) in bytes.iter().enumerate() {
-            ptr_value |= c_ulonglong::from(*b) << (i * 8);
-        }
+        let ptr_value = c_ulonglong::from_ne_bytes(res.to_ne_bytes());
         if ptr_value == 0 {
             break;
         }
         count += 1;
-        offset += std::mem::size_of::<c_ulonglong>() as isize;
     }
 
     count

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -1,12 +1,22 @@
+#![allow(
+    clippy::cast_sign_loss,
+    clippy::type_complexity,
+    clippy::used_underscore_binding
+)]
+
 use crate::arch::SyscallArgType;
+#[cfg(target_arch = "riscv64")]
 use libc::{c_ulonglong, user_regs_struct};
 use std::ops::Index;
 use syscalls::riscv64::Sysno;
+#[cfg(target_arch = "riscv64")]
 use syscalls::SysnoSet;
 
 #[allow(clippy::enum_glob_use)]
+#[cfg(target_arch = "riscv64")]
 use syscalls::riscv64::Sysno::*;
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_DESC: SysnoSet = SysnoSet::new(&[
     // strace/src/linux/64/syscallent.h
     fsetxattr,
@@ -120,6 +130,7 @@ pub static TRACE_DESC: SysnoSet = SysnoSet::new(&[
     process_mrelease,
 ]);
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_FILE: SysnoSet = SysnoSet::new(&[
     // strace/src/linux/64/syscallent.h
     setxattr,
@@ -172,10 +183,12 @@ pub static TRACE_FILE: SysnoSet = SysnoSet::new(&[
     mount_setattr,
 ]);
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_IPC: SysnoSet = SysnoSet::new(&[
     msgget, msgctl, msgrcv, msgsnd, semget, semctl, semtimedop, semop, shmget, shmctl, shmat, shmdt,
 ]);
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_NETWORK: SysnoSet = SysnoSet::new(&[
     sendfile,
     socket,
@@ -198,6 +211,7 @@ pub static TRACE_NETWORK: SysnoSet = SysnoSet::new(&[
     sendmmsg,
 ]);
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_PROCESS: SysnoSet = SysnoSet::new(&[
     // strace/src/linux/64/syscallent.h
     exit,
@@ -217,12 +231,10 @@ pub static TRACE_PROCESS: SysnoSet = SysnoSet::new(&[
     clone3,
 ]);
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_SIGNAL: SysnoSet = SysnoSet::new(&[
     // strace/src/linux/64/syscallent.h
-    statfs,
-    fstatfs,
     signalfd4,
-    fstat,
     kill,
     tkill,
     tgkill,
@@ -234,15 +246,13 @@ pub static TRACE_SIGNAL: SysnoSet = SysnoSet::new(&[
     rt_sigtimedwait,
     rt_sigqueueinfo,
     rt_sigreturn,
-    execve,
     rt_tgsigqueueinfo,
-    execveat,
-    statx,
     // strace/src/linux/generic/syscallent-common.h
     pidfd_send_signal,
     io_uring_enter,
 ]);
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_MEMORY: SysnoSet = SysnoSet::new(&[
     // strace/src/linux/64/syscallent.h
     io_setup,
@@ -276,46 +286,32 @@ pub static TRACE_MEMORY: SysnoSet = SysnoSet::new(&[
     // riscv_flush_icache,
 ]);
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_STAT: SysnoSet = SysnoSet::new(&[fstat, statx]);
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_LSTAT: SysnoSet = SysnoSet::new(&[]);
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_FSTAT: SysnoSet = SysnoSet::new(&[fstat, statx]);
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_STAT_LIKE: SysnoSet = SysnoSet::new(&[fstat, statx]);
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_STATFS: SysnoSet = SysnoSet::new(&[statfs, fstatfs]);
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_FSTATFS: SysnoSet = SysnoSet::new(&[fstatfs]);
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_STATFS_LIKE: SysnoSet = SysnoSet::new(&[statfs, fstatfs]);
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_PURE: SysnoSet =
     SysnoSet::new(&[getpid, getppid, getuid, geteuid, getgid, getegid, gettid]);
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_CREDS: SysnoSet = SysnoSet::new(&[
-    capget,
-    capset,
-    clock_settime,
-    clock_gettime,
-    clock_getres,
-    setregid,
-    setgid,
-    setreuid,
-    setuid,
-    setresuid,
-    getresuid,
-    setresgid,
-    getresgid,
-    setfsuid,
-    setfsgid,
-    getgroups,
-    setgroups,
-    prctl,
-    gettimeofday,
-    settimeofday,
-    adjtimex,
-    getuid,
-    geteuid,
-    getgid,
-    getegid,
-    clock_adjtime,
+    capget, capset, setregid, setgid, setreuid, setuid, setresuid, getresuid, setresgid, getresgid,
+    setfsuid, setfsgid, getgroups, setgroups, prctl, getuid, geteuid, getgid, getegid,
 ]);
 
+#[cfg(target_arch = "riscv64")]
 pub static TRACE_CLOCK: SysnoSet = SysnoSet::new(&[
     clock_settime,
     clock_gettime,
@@ -354,6 +350,13 @@ const ADDR: Option<SyscallArgType> = Some(SyscallArgType::Addr);
 const INT: Option<SyscallArgType> = Some(SyscallArgType::Int);
 const STR: Option<SyscallArgType> = Some(SyscallArgType::Str);
 const STRV: Option<SyscallArgType> = Some(SyscallArgType::StrArray);
+const STRVS: Option<SyscallArgType> = Some(SyscallArgType::StrArraySummary);
+const IN1: Option<SyscallArgType> = Some(SyscallArgType::InputBuffer(1));
+const IN2: Option<SyscallArgType> = Some(SyscallArgType::InputBuffer(2));
+const IN3: Option<SyscallArgType> = Some(SyscallArgType::InputBuffer(3));
+const OUT1: Option<SyscallArgType> = Some(SyscallArgType::OutputBuffer(1));
+const OUT2: Option<SyscallArgType> = Some(SyscallArgType::OutputBuffer(2));
+const OUT3: Option<SyscallArgType> = Some(SyscallArgType::OutputBuffer(3));
 
 pub struct Riscv64Syscalls {
     _0: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 38],
@@ -392,20 +395,20 @@ pub static SYSCALLS: Riscv64Syscalls = Riscv64Syscalls {
         syscall!(io_submit, INT, INT, ADDR),
         syscall!(io_cancel, INT, ADDR, ADDR),
         syscall!(io_getevents, INT, INT, INT, ADDR, ADDR),
-        syscall!(setxattr, STR, STR, ADDR, INT, INT),
-        syscall!(lsetxattr, STR, STR, ADDR, INT, INT),
-        syscall!(fsetxattr, INT, STR, ADDR, INT, INT),
-        syscall!(getxattr, STR, STR, ADDR, INT),
-        syscall!(lgetxattr, STR, STR, ADDR, INT),
-        syscall!(fgetxattr, INT, STR, ADDR, INT),
-        syscall!(listxattr, STR, STR, INT),
-        syscall!(llistxattr, STR, STR, INT),
-        syscall!(flistxattr, INT, STR, INT),
+        syscall!(setxattr, STR, STR, IN3, INT, INT),
+        syscall!(lsetxattr, STR, STR, IN3, INT, INT),
+        syscall!(fsetxattr, INT, STR, IN3, INT, INT),
+        syscall!(getxattr, STR, STR, OUT3, INT),
+        syscall!(lgetxattr, STR, STR, OUT3, INT),
+        syscall!(fgetxattr, INT, STR, OUT3, INT),
+        syscall!(listxattr, STR, OUT2, INT),
+        syscall!(llistxattr, STR, OUT2, INT),
+        syscall!(flistxattr, INT, OUT2, INT),
         syscall!(removexattr, STR, STR),
         syscall!(lremovexattr, STR, STR),
         syscall!(fremovexattr, INT, STR),
-        syscall!(getcwd, STR, INT),
-        syscall!(lookup_dcookie, INT, STR, INT),
+        syscall!(getcwd, OUT1, INT),
+        syscall!(lookup_dcookie, INT, OUT2, INT),
         syscall!(eventfd2, INT, INT),
         syscall!(epoll_create1, INT),
         syscall!(epoll_ctl, INT, INT, INT, ADDR),
@@ -451,12 +454,12 @@ pub static SYSCALLS: Riscv64Syscalls = Riscv64Syscalls {
         syscall!(quotactl, INT, STR, INT, ADDR),
         syscall!(getdents64, INT, ADDR, INT),
         syscall!(lseek, INT, INT, INT),
-        syscall!(read, INT, STR, INT),
-        syscall!(write, INT, STR, INT),
+        syscall!(read, INT, OUT2, INT),
+        syscall!(write, INT, IN2, INT),
         syscall!(readv, INT, ADDR, INT),
         syscall!(writev, INT, ADDR, INT),
-        syscall!(pread64, INT, STR, INT, INT),
-        syscall!(pwrite64, INT, STR, INT, INT),
+        syscall!(pread64, INT, OUT2, INT, INT),
+        syscall!(pwrite64, INT, IN2, INT, INT),
         syscall!(preadv, INT, ADDR, INT, INT, INT),
         syscall!(pwritev, INT, ADDR, INT, INT, INT),
         syscall!(sendfile, INT, INT, ADDR, INT),
@@ -466,7 +469,7 @@ pub static SYSCALLS: Riscv64Syscalls = Riscv64Syscalls {
         syscall!(vmsplice, INT, ADDR, INT, INT),
         syscall!(splice, INT, ADDR, INT, ADDR, INT, INT),
         syscall!(tee, INT, INT, INT, INT),
-        syscall!(readlinkat, INT, STR, STR, INT),
+        syscall!(readlinkat, INT, STR, OUT3, INT),
     ],
     _80: [
         syscall!(fstat, INT, ADDR),
@@ -505,7 +508,7 @@ pub static SYSCALLS: Riscv64Syscalls = Riscv64Syscalls {
         syscall!(clock_gettime, INT, ADDR),
         syscall!(clock_getres, INT, ADDR),
         syscall!(clock_nanosleep, INT, INT, ADDR, ADDR),
-        syscall!(syslog, INT, STR, INT),
+        syscall!(syslog, INT, OUT2, INT),
         syscall!(ptrace, INT, INT, INT, INT),
         syscall!(sched_setparam, INT, ADDR),
         syscall!(sched_setscheduler, INT, INT, ADDR),
@@ -550,8 +553,8 @@ pub static SYSCALLS: Riscv64Syscalls = Riscv64Syscalls {
         syscall!(getgroups, INT, ADDR),
         syscall!(setgroups, INT, ADDR),
         syscall!(uname, ADDR),
-        syscall!(sethostname, STR, INT),
-        syscall!(setdomainname, STR, INT),
+        syscall!(sethostname, IN1, INT),
+        syscall!(setdomainname, IN1, INT),
         syscall!(getrlimit, INT, ADDR),
         syscall!(setrlimit, INT, ADDR),
         syscall!(getrusage, INT, ADDR),
@@ -571,8 +574,8 @@ pub static SYSCALLS: Riscv64Syscalls = Riscv64Syscalls {
         syscall!(sysinfo, ADDR),
         syscall!(mq_open, STR, INT, INT, ADDR),
         syscall!(mq_unlink, STR),
-        syscall!(mq_timedsend, INT, STR, INT, INT, ADDR),
-        syscall!(mq_timedreceive, INT, STR, INT, ADDR, ADDR),
+        syscall!(mq_timedsend, INT, IN2, INT, INT, ADDR),
+        syscall!(mq_timedreceive, INT, OUT2, INT, ADDR, ADDR),
         syscall!(mq_notify, INT, ADDR),
         syscall!(mq_getsetattr, INT, ADDR, ADDR),
         syscall!(msgget, INT, INT),
@@ -595,10 +598,10 @@ pub static SYSCALLS: Riscv64Syscalls = Riscv64Syscalls {
         syscall!(connect, INT, ADDR, INT),
         syscall!(getsockname, INT, ADDR, ADDR),
         syscall!(getpeername, INT, ADDR, ADDR),
-        syscall!(sendto, INT, ADDR, INT, INT, ADDR, INT),
-        syscall!(recvfrom, INT, ADDR, INT, INT, ADDR, ADDR),
-        syscall!(setsockopt, INT, INT, INT, STR, INT),
-        syscall!(getsockopt, INT, INT, INT, STR, ADDR),
+        syscall!(sendto, INT, IN2, INT, INT, ADDR, INT),
+        syscall!(recvfrom, INT, OUT2, INT, INT, ADDR, ADDR),
+        syscall!(setsockopt, INT, INT, INT, ADDR, INT),
+        syscall!(getsockopt, INT, INT, INT, ADDR, ADDR),
         syscall!(shutdown, INT, INT),
         syscall!(sendmsg, INT, ADDR, INT),
         syscall!(recvmsg, INT, ADDR, INT),
@@ -606,11 +609,11 @@ pub static SYSCALLS: Riscv64Syscalls = Riscv64Syscalls {
         syscall!(brk, INT),
         syscall!(munmap, INT, INT),
         syscall!(mremap, INT, INT, INT, INT, INT),
-        syscall!(add_key, STR, STR, ADDR, INT, INT),
+        syscall!(add_key, STR, STR, IN3, INT, INT),
         syscall!(request_key, STR, STR, STR, INT),
         syscall!(keyctl, INT, INT, INT, INT, INT),
         syscall!(clone, INT, INT, ADDR, INT, ADDR),
-        syscall!(execve, STR, STRV, STRV),
+        syscall!(execve, STR, STRV, STRVS),
         syscall!(mmap, ADDR, INT, INT, INT, INT, INT),
         syscall!(fadvise64, INT, INT, INT, INT),
         syscall!(swapon, STR, INT),
@@ -655,10 +658,10 @@ pub static SYSCALLS: Riscv64Syscalls = Riscv64Syscalls {
         syscall!(sched_getattr, INT, ADDR, INT, INT),
         syscall!(renameat2, INT, STR, INT, STR, INT),
         syscall!(seccomp, INT, INT, ADDR),
-        syscall!(getrandom, STR, INT, INT),
+        syscall!(getrandom, OUT1, INT, INT),
         syscall!(memfd_create, STR, INT),
         syscall!(bpf, INT, ADDR, INT),
-        syscall!(execveat, INT, STR, STRV, STRV, INT),
+        syscall!(execveat, INT, STR, STRV, STRVS, INT),
         syscall!(userfaultfd, INT),
         syscall!(membarrier, INT, INT, INT),
         syscall!(mlock2, INT, INT, INT),
@@ -705,6 +708,7 @@ pub static SYSCALLS: Riscv64Syscalls = Riscv64Syscalls {
     ],
 };
 
+#[cfg(target_arch = "riscv64")]
 pub fn get_arg_value(registers: user_regs_struct, i: usize) -> c_ulonglong {
     match i {
         0 => registers.a0,

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -214,6 +214,7 @@ pub static TRACE_PROCESS: SysnoSet = SysnoSet::new(&[
 ]);
 
 pub static TRACE_SIGNAL: SysnoSet = SysnoSet::new(&[
+    kill,
     rt_sigaction,
     rt_sigprocmask,
     rt_sigreturn,
@@ -312,12 +313,19 @@ const ADDR: Option<SyscallArgType> = Some(SyscallArgType::Addr);
 const INT: Option<SyscallArgType> = Some(SyscallArgType::Int);
 const STR: Option<SyscallArgType> = Some(SyscallArgType::Str);
 const STRV: Option<SyscallArgType> = Some(SyscallArgType::StrArray);
+const STRVS: Option<SyscallArgType> = Some(SyscallArgType::StrArraySummary);
+const IN1: Option<SyscallArgType> = Some(SyscallArgType::InputBuffer(1));
+const IN2: Option<SyscallArgType> = Some(SyscallArgType::InputBuffer(2));
+const IN3: Option<SyscallArgType> = Some(SyscallArgType::InputBuffer(3));
+const OUT1: Option<SyscallArgType> = Some(SyscallArgType::OutputBuffer(1));
+const OUT2: Option<SyscallArgType> = Some(SyscallArgType::OutputBuffer(2));
+const OUT3: Option<SyscallArgType> = Some(SyscallArgType::OutputBuffer(3));
 
 pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC
-    syscall!(read, INT, STR, INT),
+    syscall!(read, INT, OUT2, INT),
     // DESC
-    syscall!(write, INT, STR, INT),
+    syscall!(write, INT, IN2, INT),
     // DESC, FILE
     syscall!(open, STR, INT, INT),
     // DESC
@@ -348,9 +356,9 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(rt_sigreturn),
     syscall!(ioctl, INT, INT, ADDR),
     // DESC
-    syscall!(pread64, INT, STR, INT, INT),
+    syscall!(pread64, INT, OUT2, INT, INT),
     // DESC
-    syscall!(pwrite64, INT, STR, INT, INT),
+    syscall!(pwrite64, INT, IN2, INT, INT),
     // DESC
     syscall!(readv, INT, ADDR, INT),
     // DESC
@@ -397,9 +405,9 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // NETWORK
     syscall!(accept, INT, ADDR, ADDR),
     // NETWORK
-    syscall!(sendto, INT, STR, INT, INT),
+    syscall!(sendto, INT, IN2, INT, INT, ADDR, INT),
     // NETWORK
-    syscall!(recvfrom, INT, STR, INT, INT, ADDR, ADDR),
+    syscall!(recvfrom, INT, OUT2, INT, INT, ADDR, ADDR),
     // NETWORK
     syscall!(sendmsg, INT, ADDR, INT),
     // NETWORK
@@ -427,7 +435,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // PROCESS
     syscall!(vfork, ADDR),
     // PROCESS
-    syscall!(execve, STR, STRV, STRV),
+    syscall!(execve, STR, STRV, STRVS),
     // PROCESS
     syscall!(exit, INT),
     // PROCESS
@@ -466,7 +474,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC
     syscall!(getdents, INT, ADDR, INT),
     // FILE
-    syscall!(getcwd, STR, INT),
+    syscall!(getcwd, OUT1, INT),
     // FILE
     syscall!(chdir, STR),
     // DESC
@@ -486,7 +494,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // FILE
     syscall!(symlink, STR, STR),
     // FILE
-    syscall!(readlink, STR, STR, INT),
+    syscall!(readlink, STR, OUT2, INT),
     // FILE
     syscall!(chmod, STR, INT),
     // DESC
@@ -507,7 +515,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(ptrace, ADDR, INT, ADDR, ADDR),
     // CREDS, PURE
     syscall!(getuid, ADDR),
-    syscall!(syslog, INT, STR, INT),
+    syscall!(syslog, INT, OUT2, INT),
     // CREDS, PURE
     syscall!(getgid, ADDR),
     // CREDS
@@ -618,15 +626,15 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // FILE
     syscall!(swapoff, STR),
     syscall!(reboot, INT, INT, INT, ADDR),
-    syscall!(sethostname, STR, INT),
-    syscall!(setdomainname, STR, INT),
+    syscall!(sethostname, IN1, INT),
+    syscall!(setdomainname, IN1, INT),
     syscall!(iopl, INT),
     syscall!(ioperm, INT, INT, INT),
     syscall!(create_module, STR, INT),
     syscall!(init_module, ADDR, INT, STR),
     syscall!(delete_module, STR, INT),
     syscall!(get_kernel_syms, ADDR),
-    syscall!(query_module, STR, INT, STR, INT, INT),
+    syscall!(query_module, STR, INT, OUT3, INT, INT),
     // FILE
     syscall!(quotactl, INT, STR, INT, ADDR),
     syscall!(nfsservctl, INT, ADDR, ADDR),
@@ -642,23 +650,23 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC
     syscall!(readahead, INT, INT, INT),
     // FILE
-    syscall!(setxattr, STR, STR, ADDR, INT, INT),
+    syscall!(setxattr, STR, STR, IN3, INT, INT),
     // FILE
-    syscall!(lsetxattr, STR, STR, ADDR, INT, INT),
+    syscall!(lsetxattr, STR, STR, IN3, INT, INT),
     // DESC
-    syscall!(fsetxattr, INT, STR, ADDR, INT, INT),
+    syscall!(fsetxattr, INT, STR, IN3, INT, INT),
     // FILE
-    syscall!(getxattr, STR, STR, ADDR, INT),
+    syscall!(getxattr, STR, STR, OUT3, INT),
     // FILE
-    syscall!(lgetxattr, STR, STR, ADDR, INT),
+    syscall!(lgetxattr, STR, STR, OUT3, INT),
     // DESC
-    syscall!(fgetxattr, INT, STR, ADDR, INT),
+    syscall!(fgetxattr, INT, STR, OUT3, INT),
     // FILE
-    syscall!(listxattr, STR, STR, INT),
+    syscall!(listxattr, STR, OUT2, INT),
     // FILE
-    syscall!(llistxattr, STR, STR, INT),
+    syscall!(llistxattr, STR, OUT2, INT),
     // DESC
-    syscall!(flistxattr, INT, STR, INT),
+    syscall!(flistxattr, INT, OUT2, INT),
     // FILE
     syscall!(removexattr, STR, STR),
     // FILE
@@ -681,7 +689,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(io_submit, INT, INT, ADDR),
     syscall!(io_cancel, INT, ADDR, ADDR),
     syscall!(get_thread_area, ADDR),
-    syscall!(lookup_dcookie, INT, STR, INT),
+    syscall!(lookup_dcookie, INT, OUT2, INT),
     // DESC
     syscall!(epoll_create, INT),
     syscall!(epoll_ctl_old, INT, INT, INT, ADDR),
@@ -729,9 +737,9 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(mq_open, STR, INT),
     syscall!(mq_unlink, STR),
     // DESC
-    syscall!(mq_timedsend, INT, STR, INT, INT),
+    syscall!(mq_timedsend, INT, IN2, INT, INT),
     // DESC
-    syscall!(mq_timedreceive, INT, ADDR, INT, INT, ADDR),
+    syscall!(mq_timedreceive, INT, OUT2, INT, INT, ADDR),
     // DESC
     syscall!(mq_notify, INT, ADDR),
     // DESC
@@ -739,7 +747,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(kexec_load, INT, INT, ADDR, INT),
     // PROCESS
     syscall!(waitid, INT, INT, INT, INT),
-    syscall!(add_key, STR, STR, ADDR, INT, INT),
+    syscall!(add_key, STR, STR, IN3, INT, INT),
     syscall!(request_key, STR, STR, STR, INT),
     syscall!(keyctl, INT),
     syscall!(ioprio_set, INT, INT),
@@ -773,7 +781,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC, FILE
     syscall!(symlinkat, STR, INT, STR),
     // DESC, FILE
-    syscall!(readlinkat, INT, STR, STR, INT),
+    syscall!(readlinkat, INT, STR, OUT3, INT),
     // DESC, FILE
     syscall!(fchmodat, INT, STR, INT, INT),
     // DESC, FILE
@@ -862,7 +870,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC, FILE
     syscall!(renameat2, INT, STR, INT, STR),
     syscall!(seccomp, INT, INT, ADDR),
-    syscall!(getrandom, STR, INT, INT),
+    syscall!(getrandom, OUT1, INT, INT),
     // DESC
     syscall!(memfd_create, STR, INT),
     // DESC
@@ -870,7 +878,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     // DESC
     syscall!(bpf, INT, ADDR, INT),
     // DESC, PROCESS
-    syscall!(execveat, INT, STR, STRV, STRV, INT),
+    syscall!(execveat, INT, STR, STRV, STRVS, INT),
     // DESC
     syscall!(userfaultfd, INT),
     syscall!(membarrier, INT, INT, INT),
@@ -887,7 +895,7 @@ pub static SYSCALLS: [Option<(Sysno, [Option<SyscallArgType>; 6])>; 452] = [
     syscall!(pkey_alloc, INT, INT),
     syscall!(pkey_free, INT),
     // DESC, FILE, FSTAT, STAT_LIKE
-    syscall!(statx, INT, STR, INT, INT, STR),
+    syscall!(statx, INT, STR, INT, INT, ADDR),
     syscall!(io_pgetevents),
     syscall!(rseq),
     // We jump from syscall number 334 to 424 here

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,7 +3,7 @@ use crate::arch::{
     TRACE_LSTAT, TRACE_MEMORY, TRACE_NETWORK, TRACE_PROCESS, TRACE_PURE, TRACE_SIGNAL, TRACE_STAT,
     TRACE_STATFS, TRACE_STATFS_LIKE, TRACE_STAT_LIKE,
 };
-use crate::syscall_info::RetCode;
+use crate::syscall_info::{RetCode, SyscallId};
 use anyhow::bail;
 use clap::{Parser, Subcommand};
 use libc::pid_t;
@@ -91,6 +91,7 @@ impl Args {
             SysnoSet::all().iter().map(|v| (v.name(), v)).collect();
         let mut expr_negation = false;
         let mut system_calls = SysnoSet::empty();
+        let mut has_syscall_filter = false;
 
         // Sort system calls listed with --expr into their category to handle them accordingly
         for token in &self.expr {
@@ -99,12 +100,15 @@ impl Args {
                 (Some(token_key), Some(mut token_value))
                     if token_key == "t" || token_key == "trace" =>
                 {
-                    if let Some(v) = token_value.strip_prefix('!') {
-                        token_value = v;
-                        expr_negation = true;
+                    has_syscall_filter = true;
+                    system_calls = SysnoSet::empty();
+                    expr_negation = false;
+                    while let Some(value) = token_value.strip_prefix('!') {
+                        token_value = value;
+                        expr_negation = !expr_negation;
                     }
 
-                    for part in token_value.split(',') {
+                    for part in token_value.split(',').filter(|part| !part.is_empty()) {
                         if let Some(part) = part.strip_prefix('/') {
                             // The '/' prefix followed by a regex pattern to match system calls
                             if let Ok(pattern) = Regex::new(part) {
@@ -140,11 +144,8 @@ impl Args {
                             });
                         } else {
                             // The optional '?' prefix will ignore unknown system calls
-                            let mut ignore_unknown = false;
-                            if let Some(v) = token_value.strip_prefix('?') {
-                                token_value = v;
-                                ignore_unknown = true;
-                            }
+                            let (part, ignore_unknown) =
+                                part.strip_prefix('?').map_or((part, false), |v| (v, true));
                             if let Ok(val) = Sysno::from_str(part) {
                                 system_calls.insert(val);
                             } else if !ignore_unknown {
@@ -164,7 +165,7 @@ impl Args {
             } else {
                 FilterRetCode::All
             },
-            sysno_filter: if system_calls.count() == 0 {
+            sysno_filter: if !has_syscall_filter {
                 FilterSysno::All
             } else if expr_negation {
                 FilterSysno::Except(system_calls)
@@ -193,7 +194,7 @@ pub struct Filter {
 }
 
 impl Filter {
-    pub fn matches(&mut self, sys_no: Sysno, res: RetCode) -> bool {
+    pub fn matches(&self, syscall: SyscallId, res: RetCode) -> bool {
         (
             // Should this result code be printed?
             match self.ret_code_filter {
@@ -205,8 +206,12 @@ impl Filter {
             // Should this sys_no be printed?
             match &self.sysno_filter {
                 FilterSysno::All => true,
-                FilterSysno::Only(sysno_set) => sysno_set.contains(sys_no),
-                FilterSysno::Except(sysno_set) => !sysno_set.contains(sys_no),
+                FilterSysno::Only(sysno_set) => syscall
+                    .known()
+                    .is_some_and(|sysno| sysno_set.contains(sysno)),
+                FilterSysno::Except(sysno_set) => syscall
+                    .known()
+                    .is_none_or(|sysno| !sysno_set.contains(sysno)),
             }
         )
     }
@@ -231,5 +236,29 @@ mod tests {
             args.command,
             Some(ArgCommand::Command(vec!["app".to_string()])),
         );
+    }
+
+    #[test]
+    fn optional_unknown_filter_stays_empty() {
+        let args = Args::parse_from(["lurk", "-e", "trace=?not_a_syscall", "app"]);
+        let filter = args.create_filter().unwrap();
+        assert!(!filter.matches(Sysno::read.into(), RetCode::Ok(0)));
+    }
+
+    #[test]
+    fn signal_category_does_not_include_stat() {
+        let args = Args::parse_from(["lurk", "-e", "trace=%signal", "app"]);
+        let filter = args.create_filter().unwrap();
+        assert!(filter.matches(Sysno::kill.into(), RetCode::Ok(0)));
+        assert!(!filter.matches(Sysno::stat.into(), RetCode::Ok(0)));
+    }
+
+    #[test]
+    fn later_trace_expression_replaces_the_previous_one() {
+        let args = Args::parse_from(["lurk", "-e", "trace=!openat", "-e", "trace=read", "app"]);
+        let filter = args.create_filter().unwrap();
+        assert!(filter.matches(Sysno::read.into(), RetCode::Ok(0)));
+        assert!(!filter.matches(Sysno::write.into(), RetCode::Ok(1)));
+        assert!(!filter.matches(Sysno::openat.into(), RetCode::Ok(3)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,62 +1,9 @@
-//! lurk is a pretty (simple) alternative to strace.
+//! A small Linux system-call tracer.
 //!
-//! ## Installation
-//!
-//! Add the following dependencies to your `Cargo.toml`
-//!
-//! ```toml
-//! [dependencies]
-//! lurk-cli = "0.3.6"
-//! nix = { version = "0.27.1", features = ["ptrace", "signal"] }
-//! console = "0.15.8"
-//! ```
-//!
-//! ## Usage
-//!
-//! First crate a tracee using [`run_tracee`] method. Then you can construct a [`Tracer`]
-//! struct to trace the system calls via calling [`run_tracer`].
-//!
-//! ## Examples
-//!
-//! ```rust
-//! use anyhow::{bail, Result};
-//! use console::Style;
-//! use lurk_cli::{args::Args, style::StyleConfig, Tracer};
-//! use nix::unistd::{fork, ForkResult};
-//! use std::io;
-//!
-//! fn main() -> Result<()> {
-//!     let command = String::from("/usr/bin/ls");
-//!
-//!     let pid = match unsafe { fork() } {
-//!         Ok(ForkResult::Child) => {
-//!             return lurk_cli::run_tracee(&[command], &[], &None);
-//!         }
-//!         Ok(ForkResult::Parent { child }) => child,
-//!         Err(err) => bail!("fork() failed: {err}"),
-//!     };
-//!
-//!     let args = Args::default();
-//!     let output = io::stdout();
-//!     let style = StyleConfig {
-//!         pid: Style::new().cyan(),
-//!         syscall: Style::new().white().bold(),
-//!         success: Style::new().green(),
-//!         error: Style::new().red(),
-//!         result: Style::new().yellow(),
-//!         use_colors: true,
-//!     };
-//!
-//!     Tracer::new(pid, args, output, style)?.run_tracer()
-//! }
-//! ```
-//!
-//! [`run_tracee`]: crate::run_tracee
-//! [`Tracer`]: crate::Tracer
-//! [`run_tracer`]: crate::Tracer::run_tracer
+//! [`spawn_tracee`] is the preferred launcher.  [`run_tracee`] remains for
+//! compatibility with callers that perform the fork themselves.
 
 #[deny(clippy::pedantic, clippy::format_push_string)]
-// TODO: re-check the casting lints - they might indicate an issue
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
@@ -72,29 +19,32 @@ pub mod args;
 pub mod style;
 pub mod syscall_info;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use comfy_table::modifiers::UTF8_ROUND_CORNERS;
 use comfy_table::presets::UTF8_BORDERS_ONLY;
 use comfy_table::CellAlignment::Right;
 use comfy_table::{Cell, ContentArrangement, Row, Table};
 use libc::user_regs_struct;
-use nix::sys::personality::{self, Persona};
 use nix::sys::ptrace::{self, Event};
-use nix::sys::signal::Signal;
-use nix::sys::wait::{wait, WaitStatus};
-use nix::unistd::Pid;
-use std::collections::HashMap;
+use nix::sys::signal::{kill, Signal};
+use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+use nix::unistd::{fork, ForkResult, Pid};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::ffi::{CString, OsStr, OsString};
 use std::fs;
 use std::io::Write;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
-use std::process::{Command, Stdio};
-use std::time::{Duration, SystemTime};
-use style::StyleConfig;
-use syscalls::{Sysno, SysnoMap, SysnoSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+use syscalls::Sysno;
 use uzers::get_user_by_name;
 
 use crate::args::{Args, Filter};
-use crate::syscall_info::{RetCode, SyscallArgs, SyscallInfo};
+use crate::style::StyleConfig;
+use crate::syscall_info::{RetCode, SyscallArgs, SyscallId, SyscallInfo};
 
 const STRING_LIMIT: usize = 32;
 
@@ -103,13 +53,112 @@ pub struct Tracer<W: Write> {
     args: Args,
     string_limit: Option<usize>,
     filter: Filter,
-    syscalls_time: SysnoMap<Duration>,
-    syscalls_pass: SysnoMap<u64>,
-    syscalls_fail: SysnoMap<u64>,
+    syscall_stats: HashMap<SyscallId, SyscallStats>,
     style_config: StyleConfig,
     output: W,
-    // If enabled, count and collapse repeated failing execve attempts per pid
-    exec_retry_counts: std::collections::HashMap<Pid, usize>,
+    exec_retry_counts: HashMap<Pid, usize>,
+    initial_tracees: Vec<(Pid, StartupStop)>,
+}
+
+#[derive(Debug, Default)]
+struct SyscallStats {
+    time: Duration,
+    pass: u64,
+    fail: u64,
+}
+
+#[derive(Debug)]
+struct SyscallEntry {
+    syscall: SyscallId,
+    registers: user_regs_struct,
+    args: SyscallArgs,
+    started_wall: Instant,
+    started_system: Duration,
+}
+
+#[derive(Debug, Default)]
+struct TraceeState {
+    entry: Option<SyscallEntry>,
+    startup_stop: Option<StartupStop>,
+    seized: bool,
+    fallback_needs_sync: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StartupStop {
+    LegacySigstop,
+    SeizedLaunch,
+    SeizedInterrupt,
+    AutoAttachedChild,
+}
+
+enum SyscallStop {
+    Entry {
+        raw: u64,
+        arch: Option<u32>,
+        args: Option<[u64; 6]>,
+    },
+    Exit(i64, bool),
+    Unknown,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct PtraceSyscallEntry {
+    nr: u64,
+    args: [u64; 6],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct PtraceSyscallExit {
+    sval: i64,
+    is_error: u8,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct PtraceSyscallSeccomp {
+    nr: u64,
+    args: [u64; 6],
+    ret_data: u32,
+    reserved: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+union PtraceSyscallData {
+    entry: PtraceSyscallEntry,
+    exit: PtraceSyscallExit,
+    seccomp: PtraceSyscallSeccomp,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct PtraceSyscallInfo {
+    op: u8,
+    reserved: u8,
+    flags: u16,
+    arch: u32,
+    instruction_pointer: u64,
+    stack_pointer: u64,
+    data: PtraceSyscallData,
+}
+
+/// How the original tracee terminated.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TraceOutcome {
+    Exited(i32),
+    Signaled(Signal),
+}
+
+impl TraceOutcome {
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::Exited(code) => code,
+            Self::Signaled(signal) => 128 + signal as i32,
+        }
+    }
 }
 
 impl<W: Write> Tracer<W> {
@@ -123,14 +172,11 @@ impl<W: Write> Tracer<W> {
                 Some(args.string_limit.unwrap_or(STRING_LIMIT))
             },
             args,
-            syscalls_time: SysnoMap::from_iter(
-                SysnoSet::all().iter().map(|v| (v, Duration::default())),
-            ),
-            syscalls_pass: SysnoMap::from_iter(SysnoSet::all().iter().map(|v| (v, 0))),
-            syscalls_fail: SysnoMap::from_iter(SysnoSet::all().iter().map(|v| (v, 0))),
+            syscall_stats: HashMap::new(),
             style_config,
             output,
             exec_retry_counts: HashMap::new(),
+            initial_tracees: vec![(pid, StartupStop::LegacySigstop)],
         })
     }
 
@@ -138,22 +184,57 @@ impl<W: Write> Tracer<W> {
         self.output = output;
     }
 
-    #[allow(clippy::too_many_lines)]
+    /// Mark the original tracee as a child launched with `PTRACE_SEIZE`.
+    pub fn set_seized_spawn(&mut self) {
+        self.initial_tracees = vec![(self.pid, StartupStop::SeizedLaunch)];
+    }
+
+    /// Register all threads seized while attaching to an existing process.
+    pub fn set_attached_tracees(&mut self, tracees: Vec<Pid>) {
+        self.initial_tracees = tracees
+            .into_iter()
+            .map(|pid| (pid, StartupStop::SeizedInterrupt))
+            .collect();
+    }
+
     pub fn run_tracer(&mut self) -> Result<()> {
-        // Create a hashmap to track entry and exit times across all forked processes individually.
-        let mut start_times = HashMap::<Pid, Option<SystemTime>>::new();
-        // Store pre-parsed args for special syscalls (execve/execveat) captured at syscall entry
-        let mut pending_args = HashMap::<Pid, Option<SyscallArgs>>::new();
-        start_times.insert(self.pid, None);
-        pending_args.insert(self.pid, None);
+        self.run_tracer_with_outcome().map(drop)
+    }
 
+    #[allow(clippy::too_many_lines)]
+    pub fn run_tracer_with_outcome(&mut self) -> Result<TraceOutcome> {
+        let mut states: HashMap<_, _> = self
+            .initial_tracees
+            .iter()
+            .map(|(pid, startup_stop)| {
+                (
+                    *pid,
+                    TraceeState {
+                        startup_stop: Some(*startup_stop),
+                        seized: !matches!(startup_stop, StartupStop::LegacySigstop),
+                        fallback_needs_sync: matches!(startup_stop, StartupStop::SeizedInterrupt),
+                        ..TraceeState::default()
+                    },
+                )
+            })
+            .collect();
         let mut options_initialized = false;
-        let mut entry_regs = None;
+        let mut root_outcome = None;
 
-        loop {
-            let status = wait()?;
+        while !states.is_empty() {
+            let (status, task_system_time, observed_at) = match wait_for_tracee() {
+                Ok(observation) => observation,
+                Err(nix::errno::Errno::ECHILD) if states.is_empty() => break,
+                Err(error) => return Err(error.into()),
+            };
 
-            if !options_initialized {
+            let stopped = matches!(
+                &status,
+                WaitStatus::Stopped(_, _)
+                    | WaitStatus::PtraceEvent(_, _, _)
+                    | WaitStatus::PtraceSyscall(_)
+            );
+            if !options_initialized && status.pid() == Some(self.pid) && stopped {
                 if self.args.follow_forks {
                     arch::ptrace_init_options_fork(self.pid)?;
                 } else {
@@ -163,198 +244,124 @@ impl<W: Write> Tracer<W> {
             }
 
             match status {
-                // `WIFSTOPPED(status), signal is WSTOPSIG(status)
                 WaitStatus::Stopped(pid, signal) => {
-                    // There are three reasons why a child might stop with SIGTRAP:
-                    // 1) syscall entry
-                    // 2) syscall exit
-                    // 3) child calls exec
-                    //
-                    // Because we are tracing with PTRACE_O_TRACESYSGOOD, syscall entry and syscall exit
-                    // are stopped in PtraceSyscall and not here, which means if we get a SIGTRAP here,
-                    // it's because the child called exec.
-                    if signal == Signal::SIGTRAP {
-                        // At exec the address space may change; prefer registers captured
-                        // at the previous syscall entry (if present) so we can read argv/envp
-                        // from the original address space. Consume `entry_regs` if set.
-                        let regs = entry_regs.take();
-                        let pre = pending_args.remove(&pid).unwrap_or(None);
-
-                        // If we don't have entry registers (e.g. first-stop), try a best-effort
-                        // parse from the current registers before falling back to pointer hex.
-                        if regs.is_none() {
-                            if let Ok(cur_regs) = self.get_registers(pid) {
-                                if let Ok(sysno) = self.get_syscall(cur_regs) {
-                                    if sysno == Sysno::execve || sysno == Sysno::execveat {
-                                        // parse args now
-                                        let args_now = arch::parse_args(pid, sysno, cur_regs);
-                                        self.log_standard_syscall(
-                                            pid,
-                                            Some(cur_regs),
-                                            Some(args_now),
-                                            None,
-                                            None,
-                                        )?;
-                                        self.issue_ptrace_syscall_request(pid, None)?;
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-
-                        self.log_standard_syscall(pid, regs, pre, None, None)?;
+                    let state = states.entry(pid).or_default();
+                    if is_expected_plain_startup_stop(state.startup_stop, signal) {
+                        state.startup_stop = None;
                         self.issue_ptrace_syscall_request(pid, None)?;
                         continue;
                     }
 
-                    // If we trace with PTRACE_O_TRACEFORK, PTRACE_O_TRACEVFORK, and PTRACE_O_TRACECLONE,
-                    // a created child of our tracee will stop with SIGSTOP.
-                    // If our tracee creates children of their own, we want to trace their syscall times with a new value.
-                    if signal == Signal::SIGSTOP {
-                        if self.args.follow_forks {
-                            start_times.insert(pid, None);
-
-                            if !self.args.summary_only {
-                                writeln!(&mut self.output, "Attaching to child {}", pid,)?;
+                    match ptrace::getsiginfo(pid) {
+                        Ok(_) => self.issue_ptrace_syscall_request(pid, Some(signal))?,
+                        Err(nix::errno::Errno::EINVAL) if is_stopping_signal(signal) => {
+                            if !state.seized || !listen_tracee(pid)? {
+                                self.issue_ptrace_syscall_request(pid, None)?;
                             }
                         }
-
-                        self.issue_ptrace_syscall_request(pid, None)?;
-                        continue;
+                        Err(nix::errno::Errno::ESRCH) => {}
+                        Err(_) => self.issue_ptrace_syscall_request(pid, Some(signal))?,
                     }
-
-                    // The SIGCHLD signal is sent to a process when a child process terminates, interrupted, or resumes after being interrupted
-                    // This means, that if our tracee forked and said fork exits before the parent, the parent will get stopped.
-                    // Therefor issue a PTRACE_SYSCALL request to the parent to continue execution.
-                    // This is also important if we trace without the following forks option.
-                    if signal == Signal::SIGCHLD {
-                        self.issue_ptrace_syscall_request(pid, Some(signal))?;
-                        continue;
-                    }
-
-                    // If we fall through to here, we have another signal that's been sent to the tracee,
-                    // in this case, just forward the singal to the tracee to let it handle it.
-                    // TODO: Finer signal handling, edge-cases etc.
-                    ptrace::cont(pid, signal)?;
                 }
-                // WIFEXITED(status)
-                WaitStatus::Exited(pid, _) => {
-                    // If the process that exits is the original tracee, we can safely break here,
-                    // but we need to continue if the process that exits is a child of the original tracee.
-                    if self.pid == pid {
-                        break;
-                    } else {
-                        continue;
-                    };
-                }
-                // The traced process was stopped by a `PTRACE_EVENT_*` event.
-                WaitStatus::PtraceEvent(pid, _, code) => {
-                    // Handle exec events specially: prefer pre-parsed args captured at syscall
-                    // entry time (stored in `pending_args`) so we can print argv/envp even
-                    // after the address space has been replaced. When we detect an exec
-                    // event, log it as a successful exec (return 0) using the stored
-                    // args if present, otherwise fall back to best-effort parsing.
-                    if code == Event::PTRACE_EVENT_EXEC as i32 {
-                        // consume any pending args parsed at entry
-                        let pre = pending_args.remove(&pid).unwrap_or(None);
-                        if let Some(args_now) = pre {
-                            // Log as successful exec (execve should not return on success).
-                            self.log_exec_event(pid, args_now)?;
-                        } else if let Ok(regs) = self.get_registers(pid) {
-                            if let Ok(sysno) = self.get_syscall(regs) {
-                                if sysno == Sysno::execve || sysno == Sysno::execveat {
-                                    let args_now = arch::parse_args(pid, sysno, regs);
-                                    self.log_exec_event(pid, args_now)?;
-                                }
-                            }
-                        }
-                    }
-
-                    // We also stop at the PTRACE_EVENT_EXIT event because of the PTRACE_O_TRACEEXIT option.
-                    // We do this to properly catch and log exit-family syscalls, which do not have an PTRACE_SYSCALL_INFO_EXIT event.
-                    if code == Event::PTRACE_EVENT_EXIT as i32 && self.is_exit_syscall(pid)? {
-                        // use any pending args if present
-                        let pre = pending_args.remove(&pid).unwrap_or(None);
-                        self.log_standard_syscall(pid, None, pre, None, None)?;
-                    }
-
-                    self.issue_ptrace_syscall_request(pid, None)?;
-                }
-                // Tracee is traced with the PTRACE_O_TRACESYSGOOD option.
                 WaitStatus::PtraceSyscall(pid) => {
-                    // ptrace(PTRACE_GETEVENTMSG,...) can be one of three values here:
-                    // 1) PTRACE_SYSCALL_INFO_NONE
-                    // 2) PTRACE_SYSCALL_INFO_ENTRY
-                    // 3) PTRACE_SYSCALL_INFO_EXIT
-                    let event = ptrace::getevent(pid)? as u8;
-
-                    // Snapshot current time, to avoid polluting the syscall time with
-                    // non-syscall related latency.
-                    let timestamp = Some(SystemTime::now());
-
-                    // We only want to log regular syscalls on exit
-                    if let Some(syscall_start_time) = start_times.get_mut(&pid) {
-                        if event == 2 {
-                            let pre = pending_args.remove(&pid).unwrap_or(None);
-                            self.log_standard_syscall(
-                                pid,
-                                entry_regs,
-                                pre,
-                                *syscall_start_time,
-                                timestamp,
-                            )?;
-                            *syscall_start_time = None;
-                        } else {
-                            *syscall_start_time = timestamp;
-                            let regs = self.get_registers(pid)?;
-                            // Save entry registers for later use
-                            entry_regs = Some(regs);
-
-                            // Try to detect exec-like syscalls and pre-parse their args while
-                            // the address space is still intact.
-                            if let Ok(sysno) = self.get_syscall(regs) {
-                                if sysno == Sysno::execve || sysno == Sysno::execveat {
-                                    let args = arch::parse_args(pid, sysno, regs);
-                                    pending_args.insert(pid, Some(args));
-                                } else {
-                                    pending_args.insert(pid, None);
-                                }
-                            }
-                        }
-                    } else {
-                        return Err(anyhow!("Unable to get start time for tracee {}", pid));
-                    }
-
+                    self.handle_syscall_stop(pid, &mut states, task_system_time, observed_at)?;
                     self.issue_ptrace_syscall_request(pid, None)?;
                 }
-                // WIFSIGNALED(status), signal is WTERMSIG(status) and coredump is WCOREDUMP(status)
+                WaitStatus::PtraceEvent(pid, signal, code) => {
+                    if code == Event::PTRACE_EVENT_STOP as i32 {
+                        let state = states.entry(pid).or_default();
+                        state.seized = true;
+                        if is_expected_event_startup_stop(state.startup_stop, signal) {
+                            state.startup_stop = None;
+                            self.issue_ptrace_syscall_request(pid, None)?;
+                            continue;
+                        }
+                        if state.seized && is_stopping_signal(signal) && listen_tracee(pid)? {
+                            continue;
+                        }
+                        self.issue_ptrace_syscall_request(pid, None)?;
+                        continue;
+                    }
+                    if code == Event::PTRACE_EVENT_EXEC as i32 {
+                        self.migrate_exec_state(pid, &mut states)?;
+                    } else if code == Event::PTRACE_EVENT_FORK as i32
+                        || code == Event::PTRACE_EVENT_VFORK as i32
+                        || code == Event::PTRACE_EVENT_CLONE as i32
+                    {
+                        let child = Pid::from_raw(ptrace::getevent(pid)? as libc::pid_t);
+                        let child_was_known = states.contains_key(&child);
+                        let parent_seized = states.get(&pid).is_some_and(|state| state.seized);
+                        states
+                            .entry(child)
+                            .and_modify(|state| state.seized = parent_seized)
+                            .or_insert_with(|| TraceeState {
+                                startup_stop: Some(StartupStop::AutoAttachedChild),
+                                seized: parent_seized,
+                                ..TraceeState::default()
+                            });
+                        if !child_was_known && !self.args.summary_only {
+                            writeln!(&mut self.output, "Attaching to child {child}")?;
+                        }
+                    } else if code == Event::PTRACE_EVENT_EXIT as i32 {
+                        let entry = states
+                            .get_mut(&pid)
+                            .and_then(|state| state.entry.take())
+                            .filter(|entry| {
+                                entry.syscall.is(Sysno::exit) || entry.syscall.is(Sysno::exit_group)
+                            });
+                        if let Some(entry) = entry {
+                            let (wall_time, system_time) = completed_times(
+                                entry.started_wall,
+                                entry.started_system,
+                                observed_at,
+                                task_system_time,
+                            );
+                            self.log_completed_syscall(
+                                pid,
+                                entry,
+                                RetCode::Ok(0),
+                                wall_time,
+                                system_time,
+                            )?;
+                        }
+                    }
+
+                    if let Some(state) = states.get_mut(&pid) {
+                        state.startup_stop = None;
+                    }
+                    self.issue_ptrace_syscall_request(pid, None)?;
+                }
+                WaitStatus::Exited(pid, code) => {
+                    states.remove(&pid);
+                    if pid == self.pid {
+                        root_outcome = Some(TraceOutcome::Exited(code));
+                    }
+                }
                 WaitStatus::Signaled(pid, signal, coredump) => {
-                    writeln!(
-                        &mut self.output,
-                        "Child {} terminated by signal {} {}",
-                        pid,
-                        signal,
-                        if coredump { "(core dumped)" } else { "" }
-                    )?;
-                    break;
+                    states.remove(&pid);
+                    if !self.args.summary_only {
+                        writeln!(
+                            &mut self.output,
+                            "Child {pid} terminated by signal {signal}{}",
+                            if coredump { " (core dumped)" } else { "" }
+                        )?;
+                    }
+                    if pid == self.pid {
+                        root_outcome = Some(TraceOutcome::Signaled(signal));
+                    }
                 }
-                // WIFCONTINUED(status), this usually happens when a process receives a SIGCONT.
-                // Just continue with the next iteration of the loop.
-                WaitStatus::Continued(_) | WaitStatus::StillAlive => {
-                    continue;
-                }
+                WaitStatus::Continued(_) | WaitStatus::StillAlive => {}
             }
         }
 
         if !self.args.json && (self.args.summary_only || self.args.summary) {
             if !self.args.summary_only {
-                // Make a gap between the last syscall and the summary
                 writeln!(&mut self.output)?;
             }
             self.report_summary()?;
         }
 
-        Ok(())
+        root_outcome.ok_or_else(|| anyhow!("tracee disappeared without an exit status"))
     }
 
     pub fn report_summary(&mut self) -> Result<()> {
@@ -365,196 +372,221 @@ impl<W: Write> Tracer<W> {
             .apply_modifier(UTF8_ROUND_CORNERS)
             .set_content_arrangement(ContentArrangement::Dynamic)
             .set_header(&headers);
-
-        for i in 0..headers.len() {
-            table.column_mut(i).unwrap().set_cell_alignment(Right);
+        for index in 0..headers.len() {
+            table.column_mut(index).unwrap().set_cell_alignment(Right);
         }
 
-        let mut sorted_sysno: Vec<_> = self.filter.all_enabled().iter().collect();
-        sorted_sysno.sort_by_key(|k| k.name());
-        let t_time: Duration = self.syscalls_time.values().sum();
-
-        for sysno in sorted_sysno {
-            let (Some(pass), Some(fail), Some(time)) = (
-                self.syscalls_pass.get(sysno),
-                self.syscalls_fail.get(sysno),
-                self.syscalls_time.get(sysno),
-            ) else {
-                continue;
-            };
-
-            let calls = pass + fail;
-            if calls == 0 {
-                continue;
-            }
-
-            let time_percent = if !t_time.is_zero() {
-                time.as_secs_f32() / t_time.as_secs_f32() * 100f32
+        let mut stats: Vec<_> = self.syscall_stats.iter().collect();
+        stats.sort_by_key(|(syscall, _)| syscall.name());
+        let total_time: Duration = stats.iter().map(|(_, stat)| stat.time).sum();
+        for (syscall, stat) in stats {
+            let calls = stat.pass + stat.fail;
+            let percent = if total_time.is_zero() {
+                0.0
             } else {
-                0f32
+                stat.time.as_secs_f64() / total_time.as_secs_f64() * 100.0
             };
-
             table.add_row(vec![
-                Cell::new(format!("{time_percent:.1}%")),
-                Cell::new(format!("{}µs", time.as_micros())),
-                Cell::new(format!("{:.1}ns", time.as_nanos() as f64 / calls as f64)),
-                Cell::new(format!("{calls}")),
-                Cell::new(format!("{fail}")),
-                Cell::new(sysno.name()),
+                Cell::new(format!("{percent:.1}%")),
+                Cell::new(format!("{}µs", stat.time.as_micros())),
+                Cell::new(format!(
+                    "{:.1}ns",
+                    stat.time.as_nanos() as f64 / calls as f64
+                )),
+                Cell::new(calls),
+                Cell::new(stat.fail),
+                Cell::new(syscall.name()),
             ]);
         }
 
-        // Create the totals row, but don't add it to the table yet
-        let failed = self.syscalls_fail.values().sum::<u64>();
-        let calls: u64 = self.syscalls_pass.values().sum::<u64>() + failed;
+        let failed = self
+            .syscall_stats
+            .values()
+            .map(|stat| stat.fail)
+            .sum::<u64>();
+        let calls = self
+            .syscall_stats
+            .values()
+            .map(|stat| stat.pass + stat.fail)
+            .sum::<u64>();
+        let average = if calls == 0 {
+            0.0
+        } else {
+            total_time.as_nanos() as f64 / calls as f64
+        };
         let totals: Row = vec![
-            Cell::new("100%"),
-            Cell::new(format!("{}µs", t_time.as_micros())),
-            Cell::new(format!("{:.1}ns", t_time.as_nanos() as f64 / calls as f64)),
+            Cell::new(if calls == 0 { "0%" } else { "100%" }),
+            Cell::new(format!("{}µs", total_time.as_micros())),
+            Cell::new(format!("{average:.1}ns")),
             Cell::new(calls),
-            Cell::new(failed.to_string()),
+            Cell::new(failed),
             Cell::new("total"),
         ]
         .into();
-
-        // TODO: consider using another table-creating crate
-        //       https://github.com/Nukesor/comfy-table/issues/104
-        // This is a hack to add a line between the table and the summary,
-        // computing max column width of each existing row plus the totals row
         let divider_row: Vec<String> = table
             .column_max_content_widths()
             .iter()
             .copied()
             .enumerate()
-            .map(|(idx, val)| {
-                let cell_at_idx = totals.cell_iter().nth(idx).unwrap();
-                (val as usize).max(cell_at_idx.content().len())
+            .map(|(index, width)| {
+                let cell = totals.cell_iter().nth(index).unwrap();
+                (width as usize).max(cell.content().len())
             })
-            .map(|v| str::repeat("-", v))
+            .map(|width| str::repeat("-", width))
             .collect();
         table.add_row(divider_row);
         table.add_row(totals);
-
         if !self.args.summary_only {
-            // separate a list of syscalls from the summary table with an blank line
             writeln!(&mut self.output)?;
         }
         writeln!(&mut self.output, "{table}")?;
-
         Ok(())
     }
 
-    fn log_standard_syscall(
+    fn handle_syscall_stop(
         &mut self,
         pid: Pid,
-        entry_regs: Option<user_regs_struct>,
-        pre_parsed_args: Option<SyscallArgs>,
-        syscall_start_time: Option<SystemTime>,
-        syscall_end_time: Option<SystemTime>,
+        states: &mut HashMap<Pid, TraceeState>,
+        task_system_time: Duration,
+        observed_at: Instant,
     ) -> Result<()> {
-        let register_data = self.parse_register_data(pid);
-        if let Err(e) = register_data {
-            eprintln!("{e}");
-            return Ok(());
-        }
-        let (syscall_number, registers) = register_data.unwrap();
-
-        // Theres no PTRACE_SYSCALL_INFO_EXIT for an exit-family syscall, hence ret_code will always be 0xffffffffffffffda (which is -38)
-        // -38 is ENOSYS which is put into RAX as a default return value by the kernel's syscall entry code.
-        // In order to not pollute the summary with this false positive, avoid exit-family syscalls from being counted (same behaviour as strace).
-        let ret_code = match syscall_number {
-            Sysno::exit | Sysno::exit_group => RetCode::from_raw(0),
-            _ => {
-                #[cfg(target_arch = "x86_64")]
-                let code = RetCode::from_raw(registers.rax);
-                #[cfg(target_arch = "riscv64")]
-                let code = RetCode::from_raw(registers.a7);
-                #[cfg(target_arch = "aarch64")]
-                let code = RetCode::from_raw(registers.regs[0]);
-                match code {
-                    RetCode::Err(_) => self.syscalls_fail[syscall_number] += 1,
-                    _ => self.syscalls_pass[syscall_number] += 1,
+        let state = states.entry(pid).or_default();
+        let stop = read_syscall_stop(pid);
+        let stop = match stop {
+            SyscallStop::Unknown => {
+                let registers = self.get_registers(pid)?;
+                if state.fallback_needs_sync {
+                    state.fallback_needs_sync = false;
+                    if fallback_stop_is_entry(registers) == Some(false) {
+                        return Ok(());
+                    }
                 }
-                code
-            }
-        };
-
-        // Prefer entry registers if provided (they allow reading strings before exec).
-        let registers = entry_regs.unwrap_or(registers);
-
-        // Special handling: collapse repeated failing execve attempts if enabled.
-        if self.args.collapse_exec_retries
-            && (syscall_number == Sysno::execve || syscall_number == Sysno::execveat)
-        {
-            if let RetCode::Err(errno) = ret_code {
-                // ENOENT is -2: common when execvp probes PATH entries.
-                if errno == -2 {
-                    let counter = self.exec_retry_counts.entry(pid).or_default();
-                    *counter += 1;
-                    // suppress printing this failing execve
-                    return Ok(());
-                }
-            } else {
-                // success: if we suppressed prior failures, print a compact summary
-                if let Some(count) = self.exec_retry_counts.remove(&pid) {
-                    if count > 0 {
-                        writeln!(
-                            &mut self.output,
-                            "[{}] execve: collapsed {} failed attempts",
-                            pid, count
-                        )?;
+                if state.entry.is_some() {
+                    let raw = raw_return_value(registers);
+                    SyscallStop::Exit(raw, (-4095..=-1).contains(&raw))
+                } else {
+                    SyscallStop::Entry {
+                        raw: raw_syscall_number(registers),
+                        arch: registers_use_native_abi(registers).then(native_audit_arch),
+                        args: Some(register_args_for_abi(registers)),
                     }
                 }
             }
-        }
-
-        if self.filter.matches(syscall_number, ret_code) {
-            let elapsed = syscall_start_time.map_or(Duration::default(), |start_time| {
-                let end_time = syscall_end_time.unwrap_or(SystemTime::now());
-                end_time.duration_since(start_time).unwrap_or_default()
-            });
-
-            if syscall_start_time.is_some() {
-                self.syscalls_time[syscall_number] += elapsed;
+            known => {
+                state.fallback_needs_sync = false;
+                known
             }
+        };
 
-            if !self.args.summary_only {
-                // Use pre-parsed args if provided (captured at entry), otherwise parse now.
-                let args = pre_parsed_args
-                    .unwrap_or_else(|| arch::parse_args(pid, syscall_number, registers));
-                let info = SyscallInfo {
-                    typ: "SYSCALL",
-                    pid,
-                    syscall: syscall_number,
+        match stop {
+            SyscallStop::Entry {
+                raw,
+                arch,
+                args: raw_args,
+            } => {
+                let registers = self.get_registers(pid)?;
+                let syscall = SyscallId::from_raw_for_native_abi(
+                    raw,
+                    arch.is_some_and(|arch| arch == native_audit_arch()),
+                );
+                let args = syscall.known().map_or_else(
+                    || {
+                        raw_args.map_or_else(
+                            || arch::unknown_args(registers),
+                            arch::unknown_args_from_values,
+                        )
+                    },
+                    |known| arch::parse_entry_args(pid, known, registers, self.string_limit),
+                );
+                state.entry = Some(SyscallEntry {
+                    syscall,
+                    registers,
                     args,
-                    result: ret_code,
-                    duration: elapsed,
-                };
-                self.write_syscall_info(&info)?;
+                    started_wall: Instant::now(),
+                    started_system: task_system_time,
+                });
             }
+            SyscallStop::Exit(value, is_error) => {
+                let Some(mut entry) = state.entry.take() else {
+                    return Ok(());
+                };
+                if let Some(known) = entry.syscall.known() {
+                    entry.args = arch::parse_exit_args(
+                        pid,
+                        known,
+                        entry.registers,
+                        self.string_limit,
+                        value,
+                        &entry.args,
+                    );
+                }
+                let result =
+                    RetCode::from_exit(value, is_error, syscall_returns_address(entry.syscall));
+                let (wall_time, system_time) = completed_times(
+                    entry.started_wall,
+                    entry.started_system,
+                    observed_at,
+                    task_system_time,
+                );
+                self.log_completed_syscall(pid, entry, result, wall_time, system_time)?;
+            }
+            SyscallStop::Unknown => unreachable!(),
         }
-
         Ok(())
     }
 
-    fn log_exec_event(&mut self, pid: Pid, args: SyscallArgs) -> Result<()> {
-        // Construct a SyscallInfo-like record for exec events. Mark result as Ok(0)
-        // since PTRACE_EVENT_EXEC means the exec completed successfully.
-        let info = SyscallInfo {
-            typ: "SYSCALL",
-            pid,
-            syscall: Sysno::execve,
-            args,
-            result: RetCode::Ok(0),
-            duration: Duration::default(),
-        };
-        self.write_syscall_info(&info)?;
+    fn log_completed_syscall(
+        &mut self,
+        pid: Pid,
+        entry: SyscallEntry,
+        result: RetCode,
+        wall_time: Duration,
+        system_time: Duration,
+    ) -> Result<()> {
+        if !self.filter.matches(entry.syscall, result) {
+            return Ok(());
+        }
+
+        let stats = self.syscall_stats.entry(entry.syscall).or_default();
+        stats.time += system_time;
+        match result {
+            RetCode::Err(_) => stats.fail += 1,
+            RetCode::Ok(_) | RetCode::Address(_) => stats.pass += 1,
+        }
+
+        if self.args.collapse_exec_retries
+            && (entry.syscall.is(Sysno::execve) || entry.syscall.is(Sysno::execveat))
+        {
+            if result == RetCode::Err(-libc::ENOENT) {
+                *self.exec_retry_counts.entry(pid).or_default() += 1;
+                return Ok(());
+            }
+            if let Some(count) = self.exec_retry_counts.remove(&pid) {
+                if count > 0 && !self.args.summary_only {
+                    writeln!(
+                        &mut self.output,
+                        "[{pid}] execve: collapsed {count} failed attempts"
+                    )?;
+                }
+            }
+        }
+
+        if !self.args.summary_only {
+            self.write_syscall_info(&SyscallInfo {
+                typ: "SYSCALL",
+                pid,
+                syscall: entry.syscall,
+                args: entry.args,
+                result,
+                duration: wall_time,
+            })?;
+        }
         Ok(())
     }
 
     fn write_syscall_info(&mut self, info: &SyscallInfo) -> Result<()> {
         if self.args.json {
-            let json = serde_json::to_string(&info)?;
+            let json = serde_json::to_string(info)?;
             Ok(writeln!(&mut self.output, "{json}")?)
         } else {
             info.write_syscall(
@@ -567,91 +599,541 @@ impl<W: Write> Tracer<W> {
         }
     }
 
-    // Issue a PTRACE_SYSCALL request to the tracee, forwarding a signal if one is provided.
     fn issue_ptrace_syscall_request(&self, pid: Pid, signal: Option<Signal>) -> Result<()> {
-        ptrace::syscall(pid, signal)
-            .map_err(|_| anyhow!("Unable to issue a PTRACE_SYSCALL request in tracee {}", pid))
+        normalize_ptrace_restart(pid, ptrace::syscall(pid, signal))
     }
 
-    // TODO: This is arch-specific code and should be modularized
     fn get_registers(&self, pid: Pid) -> Result<user_regs_struct> {
-        ptrace::getregs(pid).map_err(|_| anyhow!("Unable to get registers from tracee {}", pid))
+        ptrace::getregs(pid)
+            .map_err(|error| anyhow!("unable to read registers from tracee {pid}: {error}"))
     }
 
-    fn get_syscall(&self, registers: user_regs_struct) -> Result<Sysno> {
-        #[cfg(target_arch = "x86_64")]
-        let reg = registers.orig_rax;
-        #[cfg(target_arch = "riscv64")]
-        let reg = registers.a7;
-        #[cfg(target_arch = "aarch64")]
-        let reg = registers.regs[8];
-
-        Ok(u32::try_from(reg)
-            .map_err(|_| anyhow!("Invalid syscall number {reg}"))?
-            .into())
-    }
-
-    // Issues a ptrace(PTRACE_GETREGS, ...) request and gets the corresponding syscall number (Sysno).
-    fn parse_register_data(&self, pid: Pid) -> Result<(Sysno, user_regs_struct)> {
-        let registers = self.get_registers(pid)?;
-        let syscall_number = self.get_syscall(registers)?;
-
-        Ok((syscall_number, registers))
-    }
-
-    fn is_exit_syscall(&self, pid: Pid) -> Result<bool> {
-        self.get_registers(pid).map(|registers| {
-            #[cfg(target_arch = "x86_64")]
-            let reg = registers.orig_rax;
-            #[cfg(target_arch = "riscv64")]
-            let reg = registers.a7;
-            #[cfg(target_arch = "aarch64")]
-            let reg = registers.regs[8];
-            reg == Sysno::exit as u64 || reg == Sysno::exit_group as u64
-        })
+    fn migrate_exec_state(
+        &mut self,
+        pid: Pid,
+        states: &mut HashMap<Pid, TraceeState>,
+    ) -> Result<()> {
+        let former_tid = Pid::from_raw(ptrace::getevent(pid)? as libc::pid_t);
+        if former_tid != pid && former_tid.as_raw() > 0 {
+            if let Some(state) = states.remove(&former_tid) {
+                states.insert(pid, state);
+            }
+            if let Some(count) = self.exec_retry_counts.remove(&former_tid) {
+                self.exec_retry_counts.insert(pid, count);
+            }
+        }
+        Ok(())
     }
 }
 
-pub fn run_tracee(command: &[String], envs: &[String], username: &Option<String>) -> Result<()> {
-    ptrace::traceme()?;
-    // Stop ourselves so the tracer parent can set ptrace options before exec.
-    // This improves reliability of capturing the initial execve syscall arguments.
-    // Make this behavior conditional: set `LURK_DISABLE_SIGSTOP=1` in the environment
-    // to skip raising SIGSTOP (useful when running under debuggers or wrappers).
-    if std::env::var_os("LURK_DISABLE_SIGSTOP").is_none() {
-        nix::sys::signal::raise(Signal::SIGSTOP).map_err(|_| anyhow!("Unable to raise SIGSTOP"))?;
+fn read_syscall_stop(pid: Pid) -> SyscallStop {
+    let mut info = std::mem::MaybeUninit::<PtraceSyscallInfo>::zeroed();
+    let result = unsafe {
+        libc::ptrace(
+            libc::PTRACE_GET_SYSCALL_INFO,
+            pid.as_raw(),
+            std::mem::size_of::<PtraceSyscallInfo>() as *mut libc::c_void,
+            info.as_mut_ptr(),
+        )
+    };
+    if result < 0 {
+        return SyscallStop::Unknown;
     }
-    personality::set(Persona::ADDR_NO_RANDOMIZE)
-        .map_err(|_| anyhow!("Unable to set ADDR_NO_RANDOMIZE"))?;
-    let mut binary = command
-        .first()
-        .ok_or_else(|| anyhow!("No command"))?
-        .to_string();
-    if let Ok(bin) = fs::canonicalize(&binary) {
-        binary = bin
-            .to_str()
-            .ok_or_else(|| anyhow!("Invalid binary path"))?
-            .to_string()
+    let info = unsafe { info.assume_init() };
+    match info.op {
+        libc::PTRACE_SYSCALL_INFO_ENTRY => SyscallStop::Entry {
+            raw: unsafe { info.data.entry.nr },
+            arch: Some(info.arch),
+            args: Some(unsafe { info.data.entry.args }),
+        },
+        libc::PTRACE_SYSCALL_INFO_EXIT => {
+            let exit = unsafe { info.data.exit };
+            SyscallStop::Exit(exit.sval, exit.is_error != 0)
+        }
+        _ => SyscallStop::Unknown,
     }
-    let mut cmd = Command::new(binary);
-    cmd.args(command[1..].iter()).stdout(Stdio::null());
+}
 
+const fn native_audit_arch() -> u32 {
+    #[cfg(target_arch = "x86_64")]
+    return 0xc000_003e;
+    #[cfg(target_arch = "aarch64")]
+    return 0xc000_00b7;
+    #[cfg(target_arch = "riscv64")]
+    return 0xc000_00f3;
+}
+
+fn registers_use_native_abi(registers: user_regs_struct) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    return registers.cs == 0x33;
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    return true;
+}
+
+fn register_args_for_abi(registers: user_regs_struct) -> [u64; 6] {
+    #[cfg(target_arch = "x86_64")]
+    if !registers_use_native_abi(registers) {
+        return [
+            registers.rbx,
+            registers.rcx,
+            registers.rdx,
+            registers.rsi,
+            registers.rdi,
+            registers.rbp,
+        ]
+        .map(|value| value & u64::from(u32::MAX));
+    }
+    arch::register_args(registers)
+}
+
+fn fallback_stop_is_entry(registers: user_regs_struct) -> Option<bool> {
+    #[cfg(target_arch = "x86_64")]
+    return Some(registers.rax as i64 == -i64::from(libc::ENOSYS));
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    return None;
+}
+
+fn raw_syscall_number(registers: user_regs_struct) -> u64 {
+    #[cfg(target_arch = "x86_64")]
+    return registers.orig_rax;
+    #[cfg(target_arch = "riscv64")]
+    return registers.a7;
+    #[cfg(target_arch = "aarch64")]
+    return registers.regs[8];
+}
+
+fn raw_return_value(registers: user_regs_struct) -> i64 {
+    #[cfg(target_arch = "x86_64")]
+    return registers.rax as i64;
+    #[cfg(target_arch = "riscv64")]
+    return registers.a0 as i64;
+    #[cfg(target_arch = "aarch64")]
+    return registers.regs[0] as i64;
+}
+
+fn syscall_returns_address(syscall: SyscallId) -> bool {
+    matches!(
+        syscall.known().map(|known| known.name()),
+        Some("mmap" | "mmap2" | "mremap" | "brk" | "shmat")
+    )
+}
+
+fn is_stopping_signal(signal: Signal) -> bool {
+    matches!(
+        signal,
+        Signal::SIGSTOP | Signal::SIGTSTP | Signal::SIGTTIN | Signal::SIGTTOU
+    )
+}
+
+fn completed_times(
+    started_wall: Instant,
+    started_system: Duration,
+    observed_at: Instant,
+    task_system_time: Duration,
+) -> (Duration, Duration) {
+    (
+        observed_at.saturating_duration_since(started_wall),
+        task_system_time.saturating_sub(started_system),
+    )
+}
+
+fn is_expected_plain_startup_stop(startup: Option<StartupStop>, signal: Signal) -> bool {
+    signal == Signal::SIGSTOP
+        && matches!(
+            startup,
+            Some(
+                StartupStop::LegacySigstop
+                    | StartupStop::SeizedLaunch
+                    | StartupStop::AutoAttachedChild
+            )
+        )
+}
+
+fn is_expected_event_startup_stop(startup: Option<StartupStop>, signal: Signal) -> bool {
+    match startup {
+        Some(StartupStop::SeizedInterrupt) => signal == Signal::SIGTRAP,
+        Some(
+            StartupStop::LegacySigstop | StartupStop::SeizedLaunch | StartupStop::AutoAttachedChild,
+        ) => signal == Signal::SIGTRAP || signal == Signal::SIGSTOP,
+        None => false,
+    }
+}
+
+fn normalize_ptrace_restart(pid: Pid, result: nix::Result<()>) -> Result<()> {
+    match result {
+        Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),
+        Err(error) => Err(anyhow!("unable to resume tracee {pid}: {error}")),
+    }
+}
+
+fn ptrace_listen(pid: Pid) -> nix::Result<()> {
+    let result = unsafe {
+        libc::ptrace(
+            libc::PTRACE_LISTEN,
+            pid.as_raw(),
+            std::ptr::null_mut::<libc::c_void>(),
+            std::ptr::null_mut::<libc::c_void>(),
+        )
+    };
+    nix::errno::Errno::result(result).map(drop)
+}
+
+fn listen_tracee(pid: Pid) -> Result<bool> {
+    match ptrace_listen(pid) {
+        Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(true),
+        Err(nix::errno::Errno::EIO) | Err(nix::errno::Errno::EINVAL) => Ok(false),
+        Err(error) => Err(anyhow!("unable to listen to stopped tracee {pid}: {error}")),
+    }
+}
+
+fn duration_from_timeval(time: libc::timeval) -> Duration {
+    let seconds = u64::try_from(time.tv_sec).unwrap_or_default();
+    let micros = u32::try_from(time.tv_usec).unwrap_or_default().min(999_999);
+    Duration::new(seconds, micros * 1_000)
+}
+
+fn wait_for_tracee() -> nix::Result<(WaitStatus, Duration, Instant)> {
+    loop {
+        let mut raw_status = 0;
+        let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
+        let pid = unsafe {
+            libc::wait4(
+                -1,
+                &mut raw_status,
+                WaitPidFlag::__WALL.bits(),
+                usage.as_mut_ptr(),
+            )
+        };
+        if pid < 0 {
+            let error = nix::errno::Errno::last();
+            if error == nix::errno::Errno::EINTR {
+                continue;
+            }
+            return Err(error);
+        }
+        let observed_at = Instant::now();
+        let usage = unsafe { usage.assume_init() };
+        let status = WaitStatus::from_raw(Pid::from_raw(pid), raw_status)?;
+        return Ok((status, duration_from_timeval(usage.ru_stime), observed_at));
+    }
+}
+
+#[derive(Debug)]
+struct Credentials {
+    uid: libc::uid_t,
+    gid: libc::gid_t,
+    groups: Vec<libc::gid_t>,
+}
+
+fn credentials(username: &Option<String>) -> Result<Option<Credentials>> {
+    let Some(username) = username else {
+        return Ok(None);
+    };
+    let user =
+        get_user_by_name(username).ok_or_else(|| anyhow!("user '{username}' does not exist"))?;
+    let groups = user
+        .groups()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|group| group.gid())
+        .collect();
+    Ok(Some(Credentials {
+        uid: user.uid(),
+        gid: user.primary_group_id(),
+        groups,
+    }))
+}
+
+fn environment(envs: &[String]) -> BTreeMap<OsString, OsString> {
+    let mut environment: BTreeMap<_, _> = std::env::vars_os().collect();
     for token in envs {
         let mut parts = token.splitn(2, '=');
-        match (parts.next(), parts.next()) {
-            (Some(key), Some(value)) => cmd.env(key, value),
-            (Some(key), None) => cmd.env_remove(key),
-            _ => unreachable!(),
-        };
-    }
-
-    if let Some(username) = username {
-        if let Some(user) = get_user_by_name(username) {
-            cmd.uid(user.uid());
+        let key = parts.next().unwrap_or_default();
+        if let Some(value) = parts.next() {
+            environment.insert(key.into(), value.into());
+        } else {
+            environment.remove(OsStr::new(key));
         }
     }
+    environment
+}
 
-    let _ = cmd.exec();
+fn resolve_executable(
+    command: &str,
+    environment: &BTreeMap<OsString, OsString>,
+) -> Result<PathBuf> {
+    let command_path = Path::new(command);
+    if command_path.components().count() > 1 {
+        return Ok(command_path.to_owned());
+    }
+    let path = environment
+        .get(OsStr::new("PATH"))
+        .ok_or_else(|| anyhow!("PATH is not set"))?;
+    std::env::split_paths(path)
+        .map(|directory| directory.join(command))
+        .find(|candidate| {
+            candidate.metadata().is_ok_and(|metadata| {
+                metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+            })
+        })
+        .ok_or_else(|| anyhow!("command '{command}' was not found in PATH"))
+}
 
-    Ok(())
+/// Fork and seize a tracee using only async-signal-safe operations in the child.
+///
+/// Credential setup is completed before tracing begins, and the child inherits
+/// the caller's standard streams and address-space randomization settings.
+pub fn spawn_tracee(command: &[String], envs: &[String], username: &Option<String>) -> Result<Pid> {
+    spawn_tracee_with_options(command, envs, username, false)
+}
+
+/// Fork and seize a tracee, installing fork-following options atomically when requested.
+pub fn spawn_tracee_with_options(
+    command: &[String],
+    envs: &[String],
+    username: &Option<String>,
+    follow_forks: bool,
+) -> Result<Pid> {
+    let program = command.first().ok_or_else(|| anyhow!("no command"))?;
+    let environment = environment(envs);
+    let executable = resolve_executable(program, &environment)?;
+    let executable = CString::new(executable.as_os_str().as_bytes())?;
+    let argv: Vec<CString> = command
+        .iter()
+        .map(|arg| CString::new(arg.as_bytes()))
+        .collect::<std::result::Result<_, _>>()?;
+    let mut argv_ptrs: Vec<_> = argv.iter().map(|arg| arg.as_ptr()).collect();
+    argv_ptrs.push(std::ptr::null());
+    let environment: Vec<CString> = environment
+        .into_iter()
+        .map(|(key, value)| {
+            let mut pair = key;
+            pair.push("=");
+            pair.push(value);
+            CString::new(pair.as_os_str().as_bytes())
+        })
+        .collect::<std::result::Result<_, _>>()?;
+    let mut env_ptrs: Vec<_> = environment.iter().map(|value| value.as_ptr()).collect();
+    env_ptrs.push(std::ptr::null());
+    let credentials = credentials(username)?;
+
+    match unsafe { fork() }.context("fork failed")? {
+        ForkResult::Parent { child } => {
+            if let Err(error) = wait_for_spawn_stop(child) {
+                terminate_unstarted_tracee(child);
+                return Err(error);
+            }
+            if let Err(error) = ptrace::seize(child, arch::ptrace_options(follow_forks)) {
+                terminate_unstarted_tracee(child);
+                return Err(anyhow!("unable to seize tracee {child}: {error}"));
+            }
+            if let Err(error) = kill(child, Signal::SIGCONT) {
+                terminate_unstarted_tracee(child);
+                return Err(anyhow!("unable to continue tracee {child}: {error}"));
+            }
+            Ok(child)
+        }
+        ForkResult::Child => unsafe {
+            if let Some(credentials) = credentials {
+                if libc::setgroups(credentials.groups.len(), credentials.groups.as_ptr()) == -1
+                    || libc::setgid(credentials.gid) == -1
+                    || libc::setuid(credentials.uid) == -1
+                {
+                    libc::_exit(126);
+                }
+            }
+            libc::raise(libc::SIGSTOP);
+            libc::execve(executable.as_ptr(), argv_ptrs.as_ptr(), env_ptrs.as_ptr());
+            let error = nix::errno::Errno::last();
+            let message = b"lurk: unable to execute command\n";
+            libc::write(libc::STDERR_FILENO, message.as_ptr().cast(), message.len());
+            libc::_exit(if error == nix::errno::Errno::ENOENT {
+                127
+            } else {
+                126
+            });
+        },
+    }
+}
+
+fn wait_for_spawn_stop(child: Pid) -> Result<()> {
+    loop {
+        match waitpid(child, Some(WaitPidFlag::WUNTRACED)) {
+            Ok(WaitStatus::Stopped(pid, Signal::SIGSTOP)) if pid == child => return Ok(()),
+            Ok(WaitStatus::Exited(_, code)) => {
+                bail!("tracee exited with status {code} before it could be seized")
+            }
+            Ok(WaitStatus::Signaled(_, signal, _)) => {
+                bail!("tracee was killed by {signal} before it could be seized")
+            }
+            Ok(status) => bail!("unexpected tracee status before seize: {status:?}"),
+            Err(nix::errno::Errno::EINTR) => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+}
+
+fn terminate_unstarted_tracee(child: Pid) {
+    let _ = kill(child, Signal::SIGKILL);
+    while let Err(nix::errno::Errno::EINTR) = waitpid(child, None) {}
+}
+
+/// Seize an existing process and, with `follow_forks`, all current threads.
+pub fn attach_tracees(pid: Pid, follow_forks: bool) -> Result<Vec<Pid>> {
+    let options = arch::ptrace_options(follow_forks);
+    ptrace::seize(pid, options).with_context(|| format!("Unable to attach to process {pid}"))?;
+    match ptrace::interrupt(pid) {
+        Ok(()) | Err(nix::errno::Errno::ESRCH) => {}
+        Err(error) => return Err(anyhow!("Unable to stop attached process {pid}: {error}")),
+    }
+
+    let mut tracees = vec![pid];
+    if !follow_forks {
+        return Ok(tracees);
+    }
+
+    let mut attempted = HashSet::from([pid]);
+    loop {
+        let mut found_new_thread = false;
+        let task_directory = format!("/proc/{pid}/task");
+        let entries = match fs::read_dir(&task_directory) {
+            Ok(entries) => entries,
+            Err(_) => break,
+        };
+        for entry in entries.flatten() {
+            let Some(tid) = entry
+                .file_name()
+                .to_str()
+                .and_then(|name| name.parse::<libc::pid_t>().ok())
+                .map(Pid::from_raw)
+            else {
+                continue;
+            };
+            if !attempted.insert(tid) {
+                continue;
+            }
+            found_new_thread = true;
+            if ptrace::seize(tid, options).is_err() {
+                continue;
+            }
+            tracees.push(tid);
+            let _ = ptrace::interrupt(tid);
+        }
+        if !found_new_thread {
+            break;
+        }
+    }
+    Ok(tracees)
+}
+
+fn apply_credentials(credentials: &Credentials) -> Result<()> {
+    let failed = unsafe {
+        libc::setgroups(credentials.groups.len(), credentials.groups.as_ptr()) == -1
+            || libc::setgid(credentials.gid) == -1
+            || libc::setuid(credentials.uid) == -1
+    };
+    if failed {
+        Err(std::io::Error::last_os_error().into())
+    } else {
+        Ok(())
+    }
+}
+
+/// Legacy child-side launcher retained for library compatibility.
+pub fn run_tracee(command: &[String], envs: &[String], username: &Option<String>) -> Result<()> {
+    if let Some(credentials) = credentials(username)? {
+        apply_credentials(&credentials)?;
+    }
+    ptrace::traceme()?;
+    nix::sys::signal::raise(Signal::SIGSTOP)?;
+    let program = command.first().ok_or_else(|| anyhow!("no command"))?;
+    let mut cmd = Command::new(program);
+    cmd.args(&command[1..]);
+    for token in envs {
+        let mut parts = token.splitn(2, '=');
+        let key = parts.next().unwrap_or_default();
+        if let Some(value) = parts.next() {
+            cmd.env(key, value);
+        } else {
+            cmd.env_remove(key);
+        }
+    }
+    let error = cmd.exec();
+    bail!("unable to execute '{program}': {error}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn startup_stop_matching_never_consumes_an_unrelated_signal() {
+        assert!(is_expected_plain_startup_stop(
+            Some(StartupStop::LegacySigstop),
+            Signal::SIGSTOP
+        ));
+        assert!(!is_expected_plain_startup_stop(
+            Some(StartupStop::LegacySigstop),
+            Signal::SIGUSR1
+        ));
+        assert!(!is_expected_plain_startup_stop(
+            Some(StartupStop::SeizedInterrupt),
+            Signal::SIGSTOP
+        ));
+        assert!(is_expected_event_startup_stop(
+            Some(StartupStop::SeizedInterrupt),
+            Signal::SIGTRAP
+        ));
+        assert!(is_expected_event_startup_stop(
+            Some(StartupStop::LegacySigstop),
+            Signal::SIGTRAP
+        ));
+    }
+
+    #[test]
+    fn esrch_is_a_benign_ptrace_restart_race() {
+        let pid = Pid::from_raw(123);
+        assert!(normalize_ptrace_restart(pid, Err(nix::errno::Errno::ESRCH)).is_ok());
+        assert!(normalize_ptrace_restart(pid, Err(nix::errno::Errno::EIO)).is_err());
+    }
+
+    #[test]
+    fn completed_time_uses_the_wait_observation_snapshot() {
+        let started = Instant::now();
+        let observed = started + Duration::from_micros(25);
+        let (wall, system) = completed_times(
+            started,
+            Duration::from_micros(10),
+            observed,
+            Duration::from_micros(17),
+        );
+        assert_eq!(wall, Duration::from_micros(25));
+        assert_eq!(system, Duration::from_micros(7));
+    }
+
+    #[cfg(target_env = "gnu")]
+    #[test]
+    fn local_syscall_info_layout_matches_libc() {
+        assert_eq!(
+            std::mem::size_of::<PtraceSyscallInfo>(),
+            std::mem::size_of::<libc::ptrace_syscall_info>()
+        );
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn compat_register_fallback_uses_the_i386_calling_convention() {
+        let mut registers = unsafe { std::mem::zeroed::<user_regs_struct>() };
+        registers.cs = 0x23;
+        registers.rbx = 1;
+        registers.rcx = 2;
+        registers.rdx = 3;
+        registers.rsi = 4;
+        registers.rdi = 5;
+        registers.rbp = 6;
+        registers.rax = (-i64::from(libc::ENOSYS)) as u64;
+        assert!(!registers_use_native_abi(registers));
+        assert_eq!(register_args_for_abi(registers), [1, 2, 3, 4, 5, 6]);
+        assert_eq!(fallback_stop_is_entry(registers), Some(true));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,39 +1,35 @@
 use std::fs::OpenOptions;
 use std::io::{self, BufWriter, IsTerminal, Write};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use clap::{CommandFactory, Parser};
 use lurk_cli::style::StyleConfig;
-use nix::sys::ptrace;
-use nix::unistd::{fork, ForkResult, Pid};
+use nix::unistd::Pid;
+use std::process::ExitCode;
 
 use lurk_cli::args::{ArgCommand, Args};
-use lurk_cli::{run_tracee, Tracer};
+use lurk_cli::{attach_tracees, spawn_tracee_with_options, Tracer};
 
-fn main() -> Result<()> {
+fn main() -> Result<ExitCode> {
     let config = Args::parse();
-    let pid = if let Some(ArgCommand::Command(command)) = &config.command {
+    let (pid, tracees, spawned) = if let Some(ArgCommand::Command(command)) = &config.command {
         if command.is_empty() {
             Args::command().print_help()?;
-            return Ok(());
+            return Ok(ExitCode::SUCCESS);
         }
         if config.attach.is_some() {
             bail!("The -p/--attach option cannot be used with a command");
         }
-        // FIXME: I suspect this breaks Rust's safety: fork() spawn a thread and that thread
-        //        is accessing the same memory as the parent thread (command/env/username/config)
-        match unsafe { fork() } {
-            Ok(ForkResult::Child) => return run_tracee(command, &config.env, &config.username),
-            Ok(ForkResult::Parent { child }) => child,
-            Err(err) => bail!("fork() failed: {err}"),
-        }
+        let pid =
+            spawn_tracee_with_options(command, &config.env, &config.username, config.follow_forks)?;
+        (pid, vec![pid], true)
     } else if let Some(pid) = config.attach {
         let pid = Pid::from_raw(pid);
-        ptrace::attach(pid).with_context(|| format!("Unable to attach to process {pid}"))?;
-        pid
+        let tracees = attach_tracees(pid, config.follow_forks)?;
+        (pid, tracees, false)
     } else {
         Args::command().print_help()?;
-        return Ok(());
+        return Ok(ExitCode::SUCCESS);
     };
 
     // TODO: we may also add a --color option to force colors, and a --no-color option to disable it
@@ -43,13 +39,21 @@ fn main() -> Result<()> {
         Box::new(BufWriter::new(
             OpenOptions::new()
                 .create(true)
-                .append(true)
+                .write(true)
+                .truncate(true)
                 .open(filepath)?,
         ))
     } else {
-        style_config.use_colors = io::stdout().is_terminal();
-        Box::new(std::io::stdout())
+        style_config.use_colors = io::stderr().is_terminal();
+        Box::new(std::io::stderr())
     };
 
-    Tracer::new(pid, config, output, style_config)?.run_tracer()
+    let mut tracer = Tracer::new(pid, config, output, style_config)?;
+    if spawned {
+        tracer.set_seized_spawn();
+    } else {
+        tracer.set_attached_tracees(tracees);
+    }
+    let outcome = tracer.run_tracer_with_outcome()?;
+    Ok(ExitCode::from(outcome.exit_code() as u8))
 }

--- a/src/syscall_info.rs
+++ b/src/syscall_info.rs
@@ -16,11 +16,87 @@ use std::io::Write;
 use std::time::Duration;
 use syscalls::Sysno;
 
+/// A syscall number as reported by the kernel.
+///
+/// The running kernel may know syscalls that the `syscalls` crate used to
+/// build lurk does not.  Keeping the raw number prevents a new syscall from
+/// crashing the tracer.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct SyscallId {
+    raw: u64,
+    known: Option<Sysno>,
+}
+
+impl SyscallId {
+    pub fn from_raw(raw: u64) -> Self {
+        Self {
+            raw,
+            known: usize::try_from(raw).ok().and_then(Sysno::new),
+        }
+    }
+
+    pub fn from_raw_for_native_abi(raw: u64, native_abi: bool) -> Self {
+        if native_abi {
+            Self::from_raw(raw)
+        } else {
+            Self { raw, known: None }
+        }
+    }
+
+    pub const fn from_known(syscall: Sysno) -> Self {
+        Self {
+            raw: syscall.id() as u64,
+            known: Some(syscall),
+        }
+    }
+
+    pub const fn raw(self) -> u64 {
+        self.raw
+    }
+
+    pub const fn known(self) -> Option<Sysno> {
+        self.known
+    }
+
+    pub fn is(self, syscall: Sysno) -> bool {
+        self.known == Some(syscall)
+    }
+
+    pub fn name(self) -> String {
+        self.known.map_or_else(
+            || {
+                if u32::try_from(self.raw).is_ok() {
+                    format!("syscall_{}", self.raw)
+                } else {
+                    format!("syscall_{:#x}", self.raw)
+                }
+            },
+            |syscall| syscall.name().to_owned(),
+        )
+    }
+}
+
+impl From<Sysno> for SyscallId {
+    fn from(value: Sysno) -> Self {
+        Self::from_known(value)
+    }
+}
+
+impl Display for SyscallId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.known {
+            Some(syscall) => Display::fmt(&syscall, f),
+            None if u32::try_from(self.raw).is_ok() => write!(f, "syscall_{}", self.raw),
+            None => write!(f, "syscall_{:#x}", self.raw),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct SyscallInfo {
     pub typ: &'static str,
     pub pid: Pid,
-    pub syscall: Sysno,
+    pub syscall: SyscallId,
     pub args: SyscallArgs,
     pub result: RetCode,
     pub duration: Duration,
@@ -37,7 +113,7 @@ impl SyscallInfo {
         Self {
             typ: "SYSCALL",
             pid,
-            syscall,
+            syscall: syscall.into(),
             args: parse_args(pid, syscall, registers),
             result: ret_code,
             duration,
@@ -55,29 +131,40 @@ impl SyscallInfo {
         if style.use_colors {
             write!(output, "[{}] ", style.pid.apply_to(&self.pid.to_string()))?;
         } else {
-            write!(output, "[{}] ", &self.pid)?;
+            write!(output, "[{}] ", self.pid)?;
         }
         if show_syscall_num {
-            write!(output, "{:>3} ", self.syscall.id())?;
+            write!(output, "{:>3} ", self.syscall.raw())?;
         }
         if style.use_colors {
             let styled = style.syscall.apply_to(self.syscall.to_string());
             write!(output, "{styled}(")
         } else {
-            write!(output, "{}(", &self.syscall)
+            write!(output, "{}(", self.syscall)
         }?;
         for (idx, arg) in self.args.0.iter().enumerate() {
             if idx > 0 {
                 write!(output, ", ")?;
             }
             // Special-case a few syscalls for more readable output
-            if self.syscall == Sysno::execve || self.syscall == Sysno::execveat {
-                // execve(filename, argv, envp)
+            let exec_env_index = if self.syscall.is(Sysno::execve) {
+                Some(2)
+            } else if self.syscall.is(Sysno::execveat) {
+                Some(3)
+            } else {
+                None
+            };
+            if let Some(env_index) = exec_env_index {
                 match (idx, arg) {
                     // argv: show array (possibly truncated by `string_limit` via write)
-                    (1, SyscallArg::StrVec(_, _)) => arg.write(output, string_limit)?,
+                    (1, SyscallArg::StrVec(_, _)) if self.syscall.is(Sysno::execve) => {
+                        arg.write(output, string_limit)?
+                    }
+                    (2, SyscallArg::StrVec(_, _)) if self.syscall.is(Sysno::execveat) => {
+                        arg.write(output, string_limit)?
+                    }
                     // envp: summarize like strace: print original pointer and count
-                    (2, SyscallArg::StrVec(vs, maybe_addr)) => {
+                    (arg_idx, SyscallArg::StrVec(vs, maybe_addr)) if arg_idx == env_index => {
                         if let Some(addr) = maybe_addr {
                             let count = if !vs.is_empty() {
                                 vs.len()
@@ -91,10 +178,13 @@ impl SyscallInfo {
                             arg.write(output, string_limit)?;
                         }
                     }
+                    (arg_idx, SyscallArg::StrArraySummary(count, addr)) if arg_idx == env_index => {
+                        write!(output, "{addr:#x} /* {count} vars */")?
+                    }
                     // default
                     _ => arg.write(output, string_limit)?,
                 }
-            } else if self.syscall == Sysno::mmap {
+            } else if self.syscall.is(Sysno::mmap) {
                 // mmap(addr, len, prot, flags, fd, offset)
                 // produce symbolic prot and flags
                 let parts = format_mmap_args(&self.args.0, string_limit);
@@ -108,7 +198,7 @@ impl SyscallInfo {
             }
         }
         write!(output, ") = ")?;
-        if self.syscall == Sysno::exit || self.syscall == Sysno::exit_group {
+        if self.syscall.is(Sysno::exit) || self.syscall.is(Sysno::exit_group) {
             write!(output, "?")?;
         } else {
             if style.use_colors {
@@ -135,7 +225,7 @@ impl Serialize for SyscallInfo {
         let mut map = serializer.serialize_map(Some(7))?;
         map.serialize_entry("type", &self.typ)?;
         map.serialize_entry("pid", &self.pid.as_raw())?;
-        map.serialize_entry("num", &self.syscall)?;
+        map.serialize_entry("num", &self.syscall.raw())?;
         map.serialize_entry("syscall", &self.syscall.to_string())?;
         map.serialize_entry("args", &self.args)?;
         match self.result {
@@ -148,7 +238,7 @@ impl Serialize for SyscallInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SyscallArgs(pub Vec<SyscallArg>);
 
 impl Serialize for SyscallArgs {
@@ -158,8 +248,12 @@ impl Serialize for SyscallArgs {
             let value = match arg {
                 SyscallArg::Int(v) => serde_json::to_value(v).unwrap(),
                 SyscallArg::Str(v) => serde_json::to_value(v).unwrap(),
+                SyscallArg::Bytes(v) => serde_json::to_value(v).unwrap(),
                 SyscallArg::Addr(v) => Value::String(format!("{v:#x}")),
                 SyscallArg::StrVec(vs, _addr) => serde_json::to_value(vs).unwrap(),
+                SyscallArg::StrArraySummary(count, address) => {
+                    serde_json::json!({"address": format!("{address:#x}"), "count": count})
+                }
             };
             seq.serialize_element(&value)?;
         }
@@ -167,23 +261,30 @@ impl Serialize for SyscallArgs {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum RetCode {
-    Ok(i32),
+    Ok(i64),
     Err(i32),
-    Address(usize),
+    Address(u64),
 }
 
 impl RetCode {
     pub fn from_raw(ret_code: c_ulonglong) -> Self {
-        let ret_i32 = ret_code as isize;
-        // TODO: is this > or >= ?  Add a link to the docs.
-        if ret_i32.abs() > 0x8000 {
-            Self::Address(ret_code as usize)
-        } else if ret_i32 < 0 {
-            Self::Err(ret_i32 as i32)
+        let signed = ret_code as i64;
+        if (-4095..=-1).contains(&signed) {
+            Self::Err(signed as i32)
         } else {
-            Self::Ok(ret_i32 as i32)
+            Self::Ok(signed)
+        }
+    }
+
+    pub fn from_exit(ret_code: i64, is_error: bool, returns_address: bool) -> Self {
+        if is_error {
+            Self::Err(ret_code as i32)
+        } else if returns_address {
+            Self::Address(ret_code as u64)
+        } else {
+            Self::Ok(ret_code)
         }
     }
 }
@@ -191,18 +292,23 @@ impl RetCode {
 impl Display for RetCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Ok(v) | Self::Err(v) => Display::fmt(v, f),
+            Self::Ok(v) => Display::fmt(v, f),
+            Self::Err(v) => Display::fmt(v, f),
             Self::Address(v) => write!(f, "{v:#X}"),
         }
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub enum SyscallArg {
     Int(i64),
     Str(String),
+    Bytes(Vec<u8>),
     // store optional original pointer address for arrays so we can summarize like strace
     StrVec(Vec<String>, Option<usize>),
+    /// A NULL-terminated string array whose contents are intentionally not
+    /// copied (used for potentially sensitive environment vectors).
+    StrArraySummary(usize, usize),
     Addr(usize),
 }
 
@@ -218,6 +324,7 @@ impl SyscallArg {
                 .into();
                 write!(f, "{value}")
             }
+            Self::Bytes(bytes) => write_bytes(f, bytes, string_limit),
             Self::StrVec(vs, _addr) => {
                 // format vector as JSON-like array, applying trimming to each element
                 let mut parts = Vec::with_capacity(vs.len());
@@ -230,15 +337,43 @@ impl SyscallArg {
                 }
                 write!(f, "[{}]", parts.join(", "))
             }
+            Self::StrArraySummary(count, address) => {
+                write!(f, "{address:#x} /* {count} entries */")
+            }
             Self::Addr(v) => write!(f, "{v:#X}"),
         }
     }
 }
 
+fn write_bytes(f: &mut dyn Write, bytes: &[u8], limit: Option<usize>) -> io::Result<()> {
+    let shown = limit.map_or(bytes.len(), |limit| limit.min(bytes.len()));
+    write!(f, "\"")?;
+    for byte in &bytes[..shown] {
+        match byte {
+            b'\\' => write!(f, "\\\\")?,
+            b'\"' => write!(f, "\\\"")?,
+            b'\n' => write!(f, "\\n")?,
+            b'\r' => write!(f, "\\r")?,
+            b'\t' => write!(f, "\\t")?,
+            0x20..=0x7e => write!(f, "{}", char::from(*byte))?,
+            _ => write!(f, "\\x{byte:02x}")?,
+        }
+    }
+    write!(f, "\"")?;
+    if shown < bytes.len() {
+        write!(f, "...")?;
+    }
+    Ok(())
+}
+
 fn trim_str(string: &str, limit: usize) -> Cow<'_, str> {
-    match string.chars().as_str().get(..limit) {
-        None => Borrowed(string),
-        Some(s) => Owned(format!("{s}...")),
+    if string.chars().count() <= limit {
+        Borrowed(string)
+    } else {
+        Owned(format!(
+            "{}...",
+            string.chars().take(limit).collect::<String>()
+        ))
     }
 }
 
@@ -325,4 +460,63 @@ fn format_mmap_args(args: &[SyscallArg], string_limit: Option<usize>) -> Vec<Str
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn return_values_are_not_truncated_or_guessed_to_be_pointers() {
+        assert_eq!(RetCode::from_raw(1_u64 << 40), RetCode::Ok(1_i64 << 40));
+        assert_eq!(RetCode::from_raw((-2_i64) as u64), RetCode::Err(-2));
+    }
+
+    #[test]
+    fn raw_syscall_numbers_keep_the_kernel_word_size() {
+        let raw = u64::MAX;
+        let syscall = SyscallId::from_raw(raw);
+        assert_eq!(syscall.raw(), raw);
+        assert_eq!(syscall.known(), None);
+        assert_eq!(syscall.to_string(), "syscall_0xffffffffffffffff");
+
+        let compat_read = SyscallId::from_raw_for_native_abi(3, false);
+        assert_eq!(compat_read.raw(), 3);
+        assert_eq!(compat_read.known(), None);
+    }
+
+    #[test]
+    fn unicode_trimming_uses_character_boundaries() {
+        assert_eq!(trim_str("ééé", 2), "éé...");
+    }
+
+    #[test]
+    fn execveat_uses_the_correct_argv_and_environment_positions() {
+        let info = SyscallInfo {
+            typ: "SYSCALL",
+            pid: Pid::from_raw(1),
+            syscall: Sysno::execveat.into(),
+            args: SyscallArgs(vec![
+                SyscallArg::Int(-100),
+                SyscallArg::Str("/bin/true".to_owned()),
+                SyscallArg::StrVec(vec!["true".to_owned()], Some(0x1000)),
+                SyscallArg::StrArraySummary(3, 0x2000),
+                SyscallArg::Int(0),
+            ]),
+            result: RetCode::Ok(0),
+            duration: Duration::ZERO,
+        };
+        let mut output = Vec::new();
+        let style = StyleConfig {
+            use_colors: false,
+            ..StyleConfig::default()
+        };
+        info.write_syscall(style, None, false, false, &mut output)
+            .unwrap();
+        let output = String::from_utf8(output).unwrap();
+        assert!(
+            output.contains("[\"true\"], 0x2000 /* 3 vars */"),
+            "{output}"
+        );
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,233 @@
+use serde_json::Value;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+fn lurk(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_lurk"))
+        .args(args)
+        .output()
+        .expect("failed to run lurk")
+}
+
+#[test]
+fn preserves_stdio_and_tracee_exit_status() {
+    let output = lurk(&["/bin/sh", "-c", "printf visible; exit 37"]);
+    assert_eq!(output.status.code(), Some(37));
+    assert_eq!(output.stdout, b"visible");
+
+    let trace = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(trace.matches("execve(").count(), 1, "{trace}");
+
+    let output = lurk(&["/bin/sh", "-c", "kill -TERM $$"]);
+    assert_eq!(output.status.code(), Some(128 + 15));
+}
+
+#[test]
+fn filters_apply_to_exec_and_summary_totals() {
+    let output = lurk(&["-e", "trace=read", "/bin/true"]);
+    assert!(output.status.success());
+    let trace = String::from_utf8_lossy(&output.stderr);
+    assert!(!trace.contains("execve("), "{trace}");
+    assert!(trace.lines().all(|line| line.contains("read(")), "{trace}");
+
+    let output = lurk(&["-c", "-e", "trace=kill", "/bin/true"]);
+    assert!(output.status.success());
+    let summary = String::from_utf8_lossy(&output.stderr);
+    assert!(summary.contains("0        0     total"), "{summary}");
+}
+
+#[test]
+fn json_exec_record_does_not_copy_the_environment() {
+    let output = Command::new(env!("CARGO_BIN_EXE_lurk"))
+        .env("LURK_TEST_SECRET", "must-not-appear")
+        .args(["-j", "-e", "trace=execve", "/bin/true"])
+        .output()
+        .expect("failed to run lurk");
+    assert!(output.status.success());
+    let trace = String::from_utf8_lossy(&output.stderr);
+    assert!(!trace.contains("must-not-appear"), "{trace}");
+    let record: Value = serde_json::from_str(trace.trim()).expect("invalid JSON trace record");
+    assert!(record["args"][2]["count"].is_number(), "{record}");
+}
+
+#[test]
+fn follows_children_without_sharing_syscall_state() {
+    let output = lurk(&[
+        "-f",
+        "-e",
+        "trace=execve",
+        "/bin/sh",
+        "-c",
+        "sleep 0.01 & wait",
+    ]);
+    assert!(output.status.success());
+    let trace = String::from_utf8_lossy(&output.stderr);
+    assert!(trace.contains("Attaching to child"), "{trace}");
+    assert!(trace.contains("[\"sleep\", \"0.01\"]"), "{trace}");
+    assert_eq!(trace.matches("execve(").count(), 2, "{trace}");
+}
+
+#[test]
+fn unknown_syscalls_do_not_crash_the_tracer() {
+    if !Path::new("/usr/bin/python3").exists() {
+        return;
+    }
+    let output = lurk(&[
+        "-e",
+        "trace=!execve",
+        "/usr/bin/python3",
+        "-c",
+        "import ctypes; ctypes.CDLL(None).syscall(470,0,0,0,0,0,0)",
+    ]);
+    assert!(output.status.success());
+    let trace = String::from_utf8_lossy(&output.stderr);
+    assert!(trace.contains("syscall_470("), "{trace}");
+    assert!(!trace.contains("panicked"), "{trace}");
+}
+
+#[test]
+fn full_width_unknown_syscall_numbers_do_not_abort_tracing() {
+    if !Path::new("/usr/bin/python3").exists() {
+        return;
+    }
+    let output = lurk(&[
+        "-e",
+        "trace=!execve",
+        "/usr/bin/python3",
+        "-S",
+        "-c",
+        "import ctypes; ctypes.CDLL(None).syscall(-1)",
+    ]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let trace = String::from_utf8_lossy(&output.stderr);
+    assert!(trace.contains("syscall_0xffffffffffffffff("), "{trace}");
+}
+
+#[test]
+fn resumes_with_syscall_tracing_after_a_caught_signal() {
+    if !Path::new("/usr/bin/python3").exists() {
+        return;
+    }
+    let output = lurk(&[
+        "-e",
+        "trace=openat",
+        "/usr/bin/python3",
+        "-c",
+        "import os,signal; signal.signal(signal.SIGUSR1,lambda *_:None); os.kill(os.getpid(),signal.SIGUSR1); open('/dev/null').close()",
+    ]);
+    assert!(output.status.success());
+    let trace = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        trace.lines().any(|line| line.contains("/dev/null")),
+        "{trace}"
+    );
+}
+
+#[test]
+fn reads_output_buffers_at_syscall_exit() {
+    if !Path::new("/usr/bin/python3").exists() {
+        return;
+    }
+    let output = lurk(&[
+        "-e",
+        "trace=read",
+        "/usr/bin/python3",
+        "-c",
+        "import os; r,w=os.pipe(); os.write(w,b'after'); os.read(r,5)",
+    ]);
+    assert!(output.status.success());
+    let trace = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        trace
+            .lines()
+            .any(|line| line.contains("read(") && line.contains("\"after\"")),
+        "{trace}"
+    );
+}
+
+#[test]
+fn launched_tracees_remain_in_job_control_stops_until_sigcont() {
+    if !Path::new("/usr/bin/python3").exists() {
+        return;
+    }
+    let program = "import os,time,signal; p=os.fork(); (time.sleep(.2),os.kill(os.getppid(),signal.SIGCONT),os._exit(0)) if p==0 else (os.kill(os.getpid(),signal.SIGSTOP),os._exit(0))";
+    let started = Instant::now();
+    let output = lurk(&[
+        "-e",
+        "trace=exit_group",
+        "/usr/bin/python3",
+        "-S",
+        "-c",
+        program,
+    ]);
+    let elapsed = started.elapsed();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        elapsed >= Duration::from_millis(150),
+        "elapsed: {elapsed:?}"
+    );
+}
+
+#[test]
+fn follow_attach_seizes_existing_threads() {
+    if !Path::new("/usr/bin/python3").exists() {
+        return;
+    }
+    let program = "import os,sys,time; p=os.fork(); code='import time,threading,ctypes; c=ctypes.CDLL(None); t=threading.Thread(target=lambda:[(c.syscall(39),time.sleep(.005)) for _ in range(40)]); t.start(); time.sleep(.3)'; (exec(code),os._exit(0)) if p==0 else (time.sleep(.05),os.execv(sys.argv[1],[sys.argv[1],'-f','-e','trace=getpid','-p',str(p)]))";
+    let output = Command::new("/usr/bin/python3")
+        .args(["-S", "-c", program, env!("CARGO_BIN_EXE_lurk")])
+        .output()
+        .expect("failed to run attach harness");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let trace = String::from_utf8_lossy(&output.stderr);
+    assert!(trace.matches("getpid(").count() > 0, "{trace}");
+}
+
+#[test]
+fn summary_uses_system_time_instead_of_blocked_wall_time() {
+    if !Path::new("/usr/bin/python3").exists() {
+        return;
+    }
+    let program = "import os,signal,time; r,w=os.pipe(); signal.signal(signal.SIGUSR1,lambda *_:None); signal.siginterrupt(signal.SIGUSR1,False); p=os.fork(); (time.sleep(.05),os.kill(os.getppid(),signal.SIGUSR1),time.sleep(.05),os.write(w,b'x'),os._exit(0)) if p==0 else (os.read(r,1),os.waitpid(p,0))";
+    let output = lurk(&[
+        "-c",
+        "-e",
+        "trace=read",
+        "/usr/bin/python3",
+        "-S",
+        "-c",
+        program,
+    ]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let summary = String::from_utf8_lossy(&output.stderr);
+    let read_row = summary
+        .lines()
+        .find(|line| line.trim_end().ends_with("read │"))
+        .unwrap_or_else(|| panic!("missing read row: {summary}"));
+    let micros = read_row
+        .split_whitespace()
+        .find_map(|field| field.strip_suffix("µs"))
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or_else(|| panic!("missing duration in row: {read_row}"));
+    assert!(
+        micros < 50_000,
+        "summary used blocked wall time: {read_row}"
+    );
+}


### PR DESCRIPTION
heyaa it's me again, with yet another rewrite of the main tracing loop.  
had these changes locally for a while now and it fixed a couple of issues for me, never had the time to polish them properly until now, but here ya go.

the main issue was that the old loop expected syscall stops to arrive in a clean entry, exit, entry, exit order. linux does not always make life that easy. signals, ptrace events, forks, execs, and attach stops can all get mixed together. the loop now keeps explicit state for every tracee and uses the information reported by the kernel whenever possible.

for reference, i compared the behavior against [strace commit `877c879`][strace-review].

## what changed

### starting and attaching tracees

there is now a `spawn_tracee` API that prepares the command, environment, and credentials before `fork`. the child stops itself, then the parent attaches through `PTRACE_SEIZE` before letting it continue.

the old launch path also started tracing while lurk was still setting up the command. this meant traces included lurk's own startup syscalls, such as `personality` and `readlink`, even though they had nothing to do with the program being traced. the new launcher finishes that setup before the child is seized, so tracing starts at the actual `execve`.

`-f -p` also attaches to threads that already exist under `/proc/PID/task`. previously it only attached to the supplied PID, which meant syscalls from existing worker threads were missed.

this is based on how strace handles [seize and interrupt][strace-seize] and [existing threads][strace-threads].

the example under `examples/` now shows the new library API as well.

### signals, stops, and child processes

startup stops, signal-delivery stops, group stops, and ptrace events are now handled separately.

this fixes a race where the first observed stop could be a real signal and still get swallowed as if it was the expected startup stop.

job control signals now keep seized tracees stopped through `PTRACE_LISTEN`. strace does the same thing in its [group-stop handling][strace-group-stops].

forked and cloned processes get their own syscall state, and that state is migrated when a nonleader thread performs `exec`.

`wait4` now retries after `EINTR`, and `ESRCH` from a ptrace restart is treated as a normal race with a process that already exited. this matches [strace's restart behavior][strace-restart].

### syscall and argument handling

syscall numbers are now kept as full `u64` values. unknown syscalls no longer abort the tracer, including values such as `syscall(-1)`.

`PTRACE_GET_SYSCALL_INFO` is used for syscall entry, exit, arguments, audit architecture, return values, and kernel error status.

compat ABI calls are kept raw when lurk does not have the right syscall table. this is better than accidentally printing the name of an unrelated native syscall. there is also an i386 register fallback for x86.

strace follows the same general model by storing syscall numbers using the [kernel word size][strace-syscall-fields] and selecting the syscall personality from [`PTRACE_GET_SYSCALL_INFO`][strace-syscall-info].

input buffers are read at syscall entry, while output buffers are read after a successful exit. this fixes calls like `read`, where the buffer does not contain the result yet at entry.

memory reads are now bounded, binary data is escaped properly, `execveat` uses the right argument positions, and exec environment vectors are summarized instead of copied into trace output. this follows [strace's abbreviated exec output][strace-exec].

### filters and timing

filters now apply through the same completed-syscall path used for output and summary statistics.

when multiple `trace=` expressions are supplied, the last one replaces the previous one. this matches [strace's qualifier behavior][strace-qualifiers].

`-T` timestamps are captured before argument decoding, so decoder work is no longer included in syscall duration.

summary mode now uses the system CPU time reported by `wait4` instead of blocked wall time. this matches [strace's default summary accounting][strace-summary].

### cli behavior

trace output now goes to stderr, leaving stdout to the traced program.

lurk also returns the traced process's exit status, including `128 + signal` when it is terminated by a signal. files passed with `-o` are truncated instead of appended to.

## testing

added coverage for signals, job control stops, followed children, existing-thread attach, unknown syscalls, compat registers, output buffers, filters, environment redaction, timing, and exit status propagation.

```text
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-targets --all-features -- --test-threads=1
git diff --check
```

so far so good, i have another PR brewing that overhauls the symbolic decoder for improved syscall argument handling/displaying, but i'll need some more time to polish that one before sending it upstream

[strace-review]: https://github.com/strace/strace/commit/877c8794ae753d60bbcc54206226515302cfe904
[strace-seize]: https://github.com/strace/strace/blob/877c8794ae753d60bbcc54206226515302cfe904/src/strace.c#L575-L586
[strace-threads]: https://github.com/strace/strace/blob/877c8794ae753d60bbcc54206226515302cfe904/src/strace.c#L1503-L1535
[strace-group-stops]: https://github.com/strace/strace/blob/877c8794ae753d60bbcc54206226515302cfe904/src/strace.c#L4184-L4196
[strace-restart]: https://github.com/strace/strace/blob/877c8794ae753d60bbcc54206226515302cfe904/src/strace.c#L601-L617
[strace-syscall-fields]: https://github.com/strace/strace/blob/877c8794ae753d60bbcc54206226515302cfe904/src/defs.h#L264-L276
[strace-syscall-info]: https://github.com/strace/strace/blob/877c8794ae753d60bbcc54206226515302cfe904/src/syscall.c#L1307-L1325
[strace-exec]: https://github.com/strace/strace/blob/877c8794ae753d60bbcc54206226515302cfe904/src/execve.c#L70-L136
[strace-qualifiers]: https://github.com/strace/strace/blob/877c8794ae753d60bbcc54206226515302cfe904/src/basic_filters.c#L219-L249
[strace-summary]: https://github.com/strace/strace/blob/877c8794ae753d60bbcc54206226515302cfe904/src/count.c#L269-L304